### PR TITLE
[Feat#11] GatherArticle, Member 엔티티 필드 추가

### DIFF
--- a/src/main/java/sumcoda/boardbuddy/entity/GatherArticle.java
+++ b/src/main/java/sumcoda/boardbuddy/entity/GatherArticle.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import sumcoda.boardbuddy.enumerate.GatherArticleStatus;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -23,9 +24,18 @@ public class GatherArticle extends BaseTimeEntity {
     @Column(nullable = false)
     private String title;
 
+    // 해당 모집글 현재 참가한 인원 (작성자를 포함하여 1로 초기화)
+    @Column(nullable = false)
+    private Integer currentParticipants = 1;
+
     // 해당 모집글 제한 인원
     @Column(nullable = false)
-    private Integer memberCount;
+    private Integer maxParticipants;
+
+    // 모집 상태 (모집중, 모집마감)
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private GatherArticleStatus status;
 
     // 모집글 설명
     @Column(nullable = false)
@@ -43,7 +53,11 @@ public class GatherArticle extends BaseTimeEntity {
     @Column(nullable = false)
     private String sido;
 
-    // 필터링 하기 위한 oo덩
+    // 필터링 하기 위한 oo시, oo구
+    @Column(nullable = false)
+    private String sigu;
+
+    // 필터링 하기 위한 oo동
     @Column(nullable = false)
     private String dong;
 
@@ -64,26 +78,30 @@ public class GatherArticle extends BaseTimeEntity {
     private List<Comment> comments = new ArrayList<>();
 
     @Builder
-    public GatherArticle(String title, Integer memberCount, String description, LocalDateTime meetingDate, LocalDateTime meetingEndDate, String sido, String dong, String meetingLocation) {
+    public GatherArticle(String title, Integer maxParticipants, GatherArticleStatus status, String description, LocalDateTime meetingDate, LocalDateTime meetingEndDate, String sido, String sigu, String dong, String meetingLocation) {
         this.title = title;
-        this.memberCount = memberCount;
+        this.maxParticipants = maxParticipants;
+        this.status = status;
         this.description = description;
         this.meetingDate = meetingDate;
         this.meetingEndDate = meetingEndDate;
         this.sido = sido;
         this.dong = dong;
+        this.sigu = sigu;
         this.meetingLocation = meetingLocation;
     }
 
     // 직접 빌더 패턴의 생성자를 활용하지 말고 해당 메서드를 활용하여 엔티티 생성
-    public static GatherArticle createGatherArticle(String title, Integer memberCount, String description, LocalDateTime meetingDate, LocalDateTime meetingEndDate, String sido, String dong, String meetingLocation) {
+    public static GatherArticle createGatherArticle(String title, Integer maxParticipants, GatherArticleStatus status, String description, LocalDateTime meetingDate, LocalDateTime meetingEndDate, String sido, String sigu, String dong, String meetingLocation) {
         return GatherArticle.builder()
                 .title(title)
-                .memberCount(memberCount)
+                .maxParticipants(maxParticipants)
+                .status(status)
                 .description(description)
                 .meetingDate(meetingDate)
                 .meetingEndDate(meetingEndDate)
                 .sido(sido)
+                .sigu(sigu)
                 .dong(dong)
                 .meetingLocation(meetingLocation)
                 .build();

--- a/src/main/java/sumcoda/boardbuddy/entity/Member.java
+++ b/src/main/java/sumcoda/boardbuddy/entity/Member.java
@@ -55,6 +55,12 @@ public class Member {
     @Column(nullable = false)
     private String sido;
 
+    // 사용자가 거주하는 oo시, oo구
+    // 일반 로그인 = 회원가입시 설정 가능
+    // 소셜 로그인 = 로그인후 마이페이지에서 별도로 설정 필요
+    @Column(nullable = false)
+    private String sigu;
+
     // 사용자가 거주하는 oo동
     // 일반 로그인 = 회원가입시 설정 가능
     // 소셜 로그인 = 로그인후 마이페이지에서 별도로 설정 필요
@@ -152,13 +158,14 @@ public class Member {
     private List<BadgeImage> badgeImages = new ArrayList<>();
 
     @Builder
-    public Member(String username, String password, String nickname, String email, String phoneNumber, String sido, String dong, String latitude, String longitude, Integer radius, Integer buddyScore, Integer monthlyJoinCount, Integer totalJoinCount, Integer excellentCount, Integer goodCount, Integer badCount, Integer noShowCount, String description, Integer rank, MemberRole memberRole, ProfileImage profileImage) {
+    public Member(String username, String password, String nickname, String email, String phoneNumber, String sido, String sigu, String dong, String latitude, String longitude, Integer radius, Integer buddyScore, Integer monthlyJoinCount, Integer totalJoinCount, Integer excellentCount, Integer goodCount, Integer badCount, Integer noShowCount, String description, Integer rank, MemberRole memberRole, ProfileImage profileImage) {
         this.username = username;
         this.password = password;
         this.nickname = nickname;
         this.email = email;
         this.phoneNumber = phoneNumber;
         this.sido = sido;
+        this.sigu = sigu;
         this.dong = dong;
         this.latitude = latitude;
         this.longitude = longitude;
@@ -177,7 +184,7 @@ public class Member {
     }
 
     // 직접 빌더 패턴의 생성자를 활용하지 말고 해당 메서드를 활용하여 엔티티 생성
-    public static Member createMember(String username, String password, String nickname, String email, String phoneNumber, String sido, String dong, String latitude, String longitude, Integer radius, Integer buddyScore, Integer monthlyJoinCount, Integer totalJoinCount, Integer excellentCount, Integer goodCount, Integer badCount, Integer noShowCount, String description, Integer rank, MemberRole memberRole, ProfileImage profileImage) {
+    public static Member createMember(String username, String password, String nickname, String email, String phoneNumber, String sido, String sigu, String dong, String latitude, String longitude, Integer radius, Integer buddyScore, Integer monthlyJoinCount, Integer totalJoinCount, Integer excellentCount, Integer goodCount, Integer badCount, Integer noShowCount, String description, Integer rank, MemberRole memberRole, ProfileImage profileImage) {
         return Member.builder()
                 .username(username)
                 .password(password)
@@ -185,6 +192,7 @@ public class Member {
                 .email(email)
                 .phoneNumber(phoneNumber)
                 .sido(sido)
+                .sigu(sigu)
                 .dong(dong)
                 .latitude(latitude)
                 .longitude(longitude)

--- a/src/main/java/sumcoda/boardbuddy/enumerate/GatherArticleStatus.java
+++ b/src/main/java/sumcoda/boardbuddy/enumerate/GatherArticleStatus.java
@@ -1,0 +1,15 @@
+package sumcoda.boardbuddy.enumerate;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum GatherArticleStatus {
+
+  OPEN("모집중"),
+  CLOSED("모집마감");
+
+  private final String value;
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> 이슈 번호 : #11 

## 📝작업 내용

> ### GatherArticle, Member 엔티티 필드 추가
- GatherArticle : 
    - status(모집중, 모집완료 - GatherArticleStatus enum 작성) 필드 추가 
    - currentParticipants(현재 인원 - 처음 작성자를 포함하도록 1로 초기화) 필드 추가 
    - 모집글 제한 인원 필드의 의미를 명확히 하기 위해 memberCount -> maxParticipants로 수정 
    - 필터링을 위하여 sigu(시, 구) 필드 추가
- Member : 
    - 필터링을 위하여 sigu(시, 구) 필드 추가