### PR TITLE
Refactor: 소셜로그인 성공 및 실패시 응답코드 및 URI 수정

### DIFF
--- a/src/main/java/sumcoda/boardbuddy/handler/auth/oauth2/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/sumcoda/boardbuddy/handler/auth/oauth2/OAuth2AuthenticationFailureHandler.java
@@ -45,7 +45,7 @@ public class OAuth2AuthenticationFailureHandler implements AuthenticationFailure
             response.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
         }
 
-        redirectStrategy.sendRedirect(request, response, " https://boardbuddyapp.vercel.app/login/oauth/callback?isSuccess=false?message=" + errorMessage);
+        redirectStrategy.sendRedirect(request, response, "https://boardbuddyapp.vercel.app/login/oauth/callback?isSuccess=false?message=" + errorMessage);
     }
 
     private String getOAuth2ErrorMessage(String errorMessage) {

--- a/src/main/java/sumcoda/boardbuddy/handler/auth/oauth2/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/sumcoda/boardbuddy/handler/auth/oauth2/OAuth2AuthenticationSuccessHandler.java
@@ -27,7 +27,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
     private final MemberRepository memberRepository;
     
     @Override
-    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException{
         log.info("OAuth2 success handler is working");
 
         RedirectStrategy redirectStrategy = new DefaultRedirectStrategy();
@@ -35,15 +35,16 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         CustomOAuth2User user =  (CustomOAuth2User) authentication.getPrincipal();
         Boolean isPhoneNumberVerifiedMember = checkIsPhoneNumberVerifiedMember(user);
 
-        response.setStatus(HttpStatus.OK.value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8");
 
-        // 최초 로그인 사용자가 아닌 사용자인 경우
+        // 기존 소셜 로그인 사용자인 경우
         if (Boolean.TRUE.equals(isPhoneNumberVerifiedMember)) {
+            response.setStatus(HttpStatus.OK.value());
             redirectStrategy.sendRedirect(request, response, "https://boardbuddyapp.vercel.app/login/oauth/callback?isLoginSucceed=true&isVerifiedMember=true&message=로그인에 성공하였습니다.");
-        // 최초 로그인 사용자인 경우
+        // 신규 소셜 로그인 사용자인 경우
         } else {
+            response.setStatus(HttpStatus.CREATED.value());
             redirectStrategy.sendRedirect(request, response , "https://boardbuddyapp.vercel.app/login/oauth/callback?isLoginSucceed=true&isVerifiedMember=false&message=로그인에 성공하였습니다.");
         }
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #이슈 번호: #43

## 📝작업 내용
- OAuth2AuthenticationSuccessHandler.java
  - 신규 소셜 로그인 사용자가 로그인시 프론트로 반환하는 응답코드 200 OK -> 201 CREATED 로 수정

- OAuth2AuthenticationFailureHandler.java
  - 소셜 로그인 실패시 리다이렉트되는 URI 내부에 공백 제거
