### PR TITLE
[Feat/#46] username 전역 설정을 위한 Global Controller Advice 추가

### DIFF
--- a/src/main/java/sumcoda/boardbuddy/controller/advice/GlobalControllerAdvice.java
+++ b/src/main/java/sumcoda/boardbuddy/controller/advice/GlobalControllerAdvice.java
@@ -1,0 +1,31 @@
+package sumcoda.boardbuddy.controller.advice;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import sumcoda.boardbuddy.dto.auth.oauth2.CustomOAuth2User;
+
+@RestControllerAdvice
+public class GlobalControllerAdvice {
+
+  @ModelAttribute("username")
+  public String populateUsername(Authentication authentication) {
+    String username = "";
+
+    if (authentication != null) {
+      if (authentication instanceof OAuth2AuthenticationToken) {
+        // OAuth2.0 사용자
+        CustomOAuth2User oauthUser = (CustomOAuth2User) authentication.getPrincipal();
+        username = oauthUser.getUsername();
+      } else {
+        // 그외 사용자
+        UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+        username = userDetails.getUsername();
+      }
+    }
+
+    return username;
+  }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #46 

## 📝작업 내용

> GlobalControllerAdvice 클래스를 추가
- 컨트롤러에서 인증된 사용자의 username을 여러 곳에서 사용해야 하는 상황이 발생함에 따라 전역적으로 처리하여 코드의 중복을 줄이고 일관성을 유지하고자 작성함.
- 전역 `@ModelAttribute`로 사용자 이름을 설정.
- populateUsername 메서드는 Authentication 객체에서 사용자 이름을 가져옴.
- OAuth2 사용자와 일반 사용자를 모두 처리함.

## 💬리뷰 요구사항
- 추가된 `@ModelAttribute`를 통해 컨트롤러 메서드에서 `@ModelAttribute("username") String username`를 작성하여 사용할 수 있습니다.
- @geunhokinn 님 도움으로 작성했습니당~