### PR TITLE
[Refactor/#49] 모집글 서비스 코드 수정

### DIFF
--- a/src/main/java/sumcoda/boardbuddy/service/GatherArticleService.java
+++ b/src/main/java/sumcoda/boardbuddy/service/GatherArticleService.java
@@ -87,7 +87,7 @@ public class GatherArticleService {
      */
     public GatherArticleResponse.ReadDTO getGatherArticle(Long id, String username) {
 
-        // // 존재하는 모집글인지 확인
+        // 존재하는 모집글인지 확인
         GatherArticle gatherArticle = gatherArticleRepository.findById(id)
                 .orElseThrow(() -> new GatherArticleNotFoundException("존재하지 않는 모집글입니다."));
 
@@ -132,9 +132,6 @@ public class GatherArticleService {
 
         // 수정
         updateRequest.updateEntity(gatherArticle);
-
-        // 저장
-        gatherArticleRepository.save(gatherArticle);
 
         return GatherArticleResponse.UpdateDTO.from(gatherArticle);
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #49 

## 📝작업 내용

> 기존 : 모집글 수정 시 엔티티를 수정한 후 save() 메서드 호출 -> 수정 : save() 메서드 제거
- jpa의 dirty checking을 통해 트랜잭션이 커밋될 때 변경된 엔티티를 자동으로 저장하기 때문에 save() 메서드를 호출하지 않아도 엔티티의 변경 사항이 데이터베이스에 저장됨. 불필요한 쿼리 생성 방지를 위하여 save() 메서드를 제거함.
