### PR TITLE
[Feat/#35] 사용자 로그인 상태 확인 기능 구현 및 주석 추가

### DIFF
--- a/src/main/java/sumcoda/boardbuddy/controller/AuthController.java
+++ b/src/main/java/sumcoda/boardbuddy/controller/AuthController.java
@@ -4,10 +4,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import sumcoda.boardbuddy.dto.AuthRequest;
+import sumcoda.boardbuddy.dto.MemberResponse;
 import sumcoda.boardbuddy.service.AuthService;
 
 import java.util.HashMap;
@@ -20,13 +23,19 @@ public class AuthController {
 
     private final AuthService authService;
 
+    /**
+     * SMS 인증 메시지를 사용자에게 보내는 요청 캐치
+     *
+     * @param sendSMSCertificationDTO 로그인 정보를 포함하는 사용자 객체
+     * @return 인증번호가 성공적으로 전달되었다면 true 아니라면 false 반환
+     **/
     @PostMapping("/api/auth/sms-certifications/send")
-    public ResponseEntity<Map<String, Object>> sendSMS(@RequestBody AuthRequest.SendSMSCertificationDTO requestDto) {
+    public ResponseEntity<Map<String, Object>> sendSMS(@RequestBody AuthRequest.SendSMSCertificationDTO sendSMSCertificationDTO) {
         log.info("send sms is working");
 
         Map<String, Object> response = new HashMap<>();
 
-        authService.sendSMS(requestDto);
+        authService.sendSMS(sendSMSCertificationDTO);
 
         response.put("data", true);
 
@@ -35,19 +44,44 @@ public class AuthController {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
-    //인증번호 확인
+    /**
+     *  SMS 인증번호 확인 요청 캐치
+     *
+     * @param validateSMSCertificationDTO 인증번호 확인을 요청한 사용자의 핸드폰 번호가 저장되어있는 DTO
+     * @return 인증 번호가 올바르게 입력되었다면 true 아니면 false 반환
+     **/
     @PostMapping("/api/auth/sms-certifications/verify")
-    public ResponseEntity<Map<String, Object>> verifyCertificationNumber(@RequestBody AuthRequest.ValidateSMSCertificationDTO requestDto) {
+    public ResponseEntity<Map<String, Object>> verifyCertificationNumber(@RequestBody AuthRequest.ValidateSMSCertificationDTO validateSMSCertificationDTO) {
         log.info("validate certification is working");
 
         Map<String, Object> response = new HashMap<>();
 
-        authService.validateCertificationNumber(requestDto);
+        authService.validateCertificationNumber(validateSMSCertificationDTO);
 
         response.put("data", true);
 
         response.put("message", "입력하신 SMS 인증 번호가 일치합니다.");
 
         return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    /**
+     * 사용자의 로그인 상태를 확인
+     *
+     * @param authentication 로그인 정보를 포함하는 사용자 객체
+     * @return 사용자가 로그인한 상태라면 해당 사용자의 프로필 반환 아니라면 null 반환
+     **/
+    @GetMapping("/api/auth/status")
+    public ResponseEntity<?> isAuthenticated(Authentication authentication) {
+
+        Map<String, Object> responseData = new HashMap<>();
+
+        MemberResponse.ProfileDTO profileDTO = authService.isAuthenticated(authentication);
+
+        responseData.put("data", profileDTO);
+
+        responseData.put("message", "유효한 세션입니다.");
+
+        return ResponseEntity.status(HttpStatus.OK).body(responseData);
     }
 }

--- a/src/main/java/sumcoda/boardbuddy/handler/exception/AuthExceptionHandler.java
+++ b/src/main/java/sumcoda/boardbuddy/handler/exception/AuthExceptionHandler.java
@@ -112,13 +112,13 @@ public class AuthExceptionHandler {
     }
 
     @ExceptionHandler(AuthenticationMissingException.class)
-    public ResponseEntity<Map<String, Object>> authenticationMissingExceptionHandler(InvalidPasswordException ex) {
+    public ResponseEntity<Map<String, Object>> authenticationMissingExceptionHandler(AuthenticationMissingException ex) {
         Map<String, Object> response = new HashMap<>();
 
         response.put("data", null);
 
         response.put("message", ex.getMessage());
 
-        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+        return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
     }
 }

--- a/src/main/java/sumcoda/boardbuddy/service/MemberService.java
+++ b/src/main/java/sumcoda/boardbuddy/service/MemberService.java
@@ -66,6 +66,7 @@ public class MemberService {
      * 회원가입 요청 캐치
      *
      * @param registerDTO 전달받은 회원가입 정보
+     * @return 회원가입에 성공한 유저의 memberId
      **/
     @Transactional
     public Long registerMember(MemberRequest.RegisterDTO registerDTO) {
@@ -104,6 +105,7 @@ public class MemberService {
      *
      * @param oAuth2RegisterDTO 소셜로그인 사용자에 대한 추가적인 회원가입 정보
      * @param authentication 로그인 정보를 포함하는 사용자 객체
+     * @return 신규 소셜 로그인 사용자의 memberId
      **/
     @Transactional
     public Long registerOAuth2Member(MemberRequest.OAuth2RegisterDTO oAuth2RegisterDTO, Authentication authentication) {

--- a/src/main/java/sumcoda/boardbuddy/util/AuthUtil.java
+++ b/src/main/java/sumcoda/boardbuddy/util/AuthUtil.java
@@ -37,4 +37,19 @@ public class AuthUtil {
 
         return username;
     }
+
+    /**
+     * 로그인 유형에 따라 사용자의 이름을 반환
+     *
+     * @param authentication 로그인 정보를 포함하는 사용자 객체
+     * @return 인증된 사용자인지 아닌지에 대한 ture or false 반환
+     */
+    public Boolean isAuthenticated(Authentication authentication) {
+
+        if (authentication == null) {
+            throw new AuthenticationMissingException("유효하지 않은 세션입니다.");
+        }
+
+        return true;
+    }
 }


### PR DESCRIPTION


## #️⃣연관된 이슈

> 이슈 번호: #35 

## 📝작업 내용

> 사용자 로그인 상태 확인 기능 구현 및 주석 추가

- AuthUtil.java
  - isAuthenticated() -> 로그인 유형에 따라 사용자의 이름을 반환하는 메서드

- AuthExceptionHandler.java
  - authenticationMissingExceptionHandler() 메서드 응답코드 500 -> 404로 변경

- AuthService.java
  - isAuthenticated() -> 사용자의 로그인 상태를 확인하는 메서드 구현

- AuthController.java
  - isAuthenticated() -> 사용자의 로그인 상태를 확인하는 요청 캐치
  - sendSMS(), verifyCertificationNumber() 메서드에 주석 추가

- MemberService.java
  - registerMember() 메서드에 주석 추가

## 💬리뷰 요구사항

일단은 AuthUtil을 활용하여 구현했습니다. 
@ModelAttribute를 활용하여 구현한 로직의 테스트가 가능하고 테스트 코드의 복잡성이 적절하다면 추후에 @@ModelAttribute 를 활용하는 로직으로 수정하겠습니다.
해당 부분 감안하시고 리뷰해주시면 감사하겠습니다.