### PR TITLE
[Fix/#193] 모집글 리스트 조회에서 중복된 게시물이 반환되는 에러 수정

### DIFF
--- a/src/main/java/sumcoda/boardbuddy/repository/gatherArticle/GatherArticleRepositoryCustom.java
+++ b/src/main/java/sumcoda/boardbuddy/repository/gatherArticle/GatherArticleRepositoryCustom.java
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import sumcoda.boardbuddy.dto.GatherArticleResponse;
 import sumcoda.boardbuddy.entity.Member;
+import sumcoda.boardbuddy.enumerate.MemberGatherArticleRole;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -21,8 +22,7 @@ public interface GatherArticleRepositoryCustom {
     Optional<GatherArticleResponse.IdDTO> findIdDTOById(Long gatherArticleId);
 
     Slice<GatherArticleResponse.ReadSliceDTO> findReadSliceDTOByLocationAndStatusAndSort(
-
-    List<String> sidoList, List<String> siguList, List<String> dongList, String status, String sort, Pageable pageable);
+            List<String> sidoList, List<String> siguList, List<String> dongList, String status, String sort, MemberGatherArticleRole role, Pageable pageable);
 
     Optional<GatherArticleResponse.SummaryInfoDTO> findSimpleInfoByGatherArticleId(Long gatherArticleId);
 

--- a/src/main/java/sumcoda/boardbuddy/repository/gatherArticle/GatherArticleRepositoryCustomImpl.java
+++ b/src/main/java/sumcoda/boardbuddy/repository/gatherArticle/GatherArticleRepositoryCustomImpl.java
@@ -113,7 +113,7 @@ public class GatherArticleRepositoryCustomImpl implements GatherArticleRepositor
 
     @Override
     public Slice<GatherArticleResponse.ReadSliceDTO> findReadSliceDTOByLocationAndStatusAndSort(
-            List<String> sidoList, List<String> sggList, List<String> emdList, String status, String sort, Pageable pageable) {
+            List<String> sidoList, List<String> sggList, List<String> emdList, String status, String sort, MemberGatherArticleRole role, Pageable pageable) {
 
         List<GatherArticleResponse.ReadSliceDTO> results = jpaQueryFactory.select(Projections.fields(
                         GatherArticleResponse.ReadSliceDTO.class,
@@ -135,7 +135,8 @@ public class GatherArticleRepositoryCustomImpl implements GatherArticleRepositor
                 .join(memberGatherArticle.member, member)
                 .where(
                         inLocation(sidoList, sggList, emdList),
-                        eqStatus(status)
+                        eqStatus(status),
+                        eqMemberGatherArticleRole(role)
                 )
                 .orderBy(getOrderSpecifier(sort))
                 .offset(pageable.getOffset())
@@ -172,6 +173,10 @@ public class GatherArticleRepositoryCustomImpl implements GatherArticleRepositor
                 .from(gatherArticle)
                 .where(gatherArticle.id.eq(gatherArticleId))
                 .fetchOne());
+    }
+
+    private BooleanExpression eqMemberGatherArticleRole(MemberGatherArticleRole role) {
+        return memberGatherArticle.memberGatherArticleRole.eq(role);
     }
 
     private BooleanExpression eqStatus(String status) {

--- a/src/main/java/sumcoda/boardbuddy/service/GatherArticleService.java
+++ b/src/main/java/sumcoda/boardbuddy/service/GatherArticleService.java
@@ -399,10 +399,12 @@ public class GatherArticleService {
 
         // 페이징 정보 생성
         Pageable pageable = PageRequest.of(page, PAGE_SIZE);
+        // AUTHOR 로 필터하기 위한 역할 선언
+        MemberGatherArticleRole role = MemberGatherArticleRole.AUTHOR;
 
         // 모집글 리스트 조회
         Slice<GatherArticleResponse.ReadSliceDTO> readSliceDTO = gatherArticleRepository.findReadSliceDTOByLocationAndStatusAndSort(
-                sidoList, sggList, emdList, status, sort, pageable);
+                sidoList, sggList, emdList, status, sort, role, pageable);
 
         // 모집글 리스트 DTO 생성 및 반환
         return GatherArticleResponse.ReadListDTO.builder()


### PR DESCRIPTION
## #️⃣연관된 이슈

> #193 

## 📝작업 내용

> GatherArticleService, GatherArticleRepositoryCustom, GatherArticleRepositoryCustomImpl 수정

- GatherArticleService.java
  - AUTHOR 로 필터하기 위한 role 변수 선언

- GatherArticleRepositoryCustom, GatherArticleRepositoryCustomImpl.java
  - 쿼리에 AUTHOR 로 필터하는 조건 추가


## 💬리뷰 요구사항(선택)

> 모집글 리스트 조회에서 중복된 게시물이 반환되는 에러를 MemberGatherArticleRole.AUTHOR 로 필터하여 에러를 해결하도록 수정하였습니다. 