### PR TITLE
[Refactor/#227] 프로필 수정 기능 리팩토링 

### DIFF
--- a/src/main/java/sumcoda/boardbuddy/service/MemberService.java
+++ b/src/main/java/sumcoda/boardbuddy/service/MemberService.java
@@ -1,5 +1,6 @@
 package sumcoda.boardbuddy.service;
 
+import com.amazonaws.services.s3.AmazonS3Client;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -40,6 +41,7 @@ public class MemberService {
 
     // 비밀번호를 암호화 하기 위한 필드
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
+//    private final AmazonS3Client amazonS3Client;
 
     /**
      * 아이디 중복검사
@@ -357,6 +359,9 @@ public class MemberService {
             }
             try {
                 FileDTO fileDTO = FileStorageUtil.saveFile(profileImageFile);
+                File file = fileDTO.getFile();
+
+                // 프로필 이미지 로컬 저장 시 필요
                 String profileImageUrl = FileStorageUtil.getLocalStoreDir(fileDTO.getSavedFilename());
 
                 ProfileImage newProfileImage = ProfileImage.buildProfileImage(
@@ -368,8 +373,32 @@ public class MemberService {
                 profileImageRepository.save(newProfileImage);
                 member.assignProfileImage(newProfileImage);
 
-                File file = fileDTO.getFile();
                 file.delete();
+
+//                 // 프로필 이미지 S3 저장 시 필요
+//                String bucketName = "";
+//                ProfileImage existingProfileImage = member.getProfileImage();
+//
+//                // 기존 프로필 이미지가 있다면 S3에서 삭제
+//                if (existingProfileImage != null) {
+//                    amazonS3Client.deleteObject(bucketName, existingProfileImage.getSavedFilename());
+//                }
+//
+//                amazonS3Client.putObject(bucketName, fileDTO.getSavedFilename(), file);
+//
+//                String awsS3URL = amazonS3Client.getUrl(bucketName, fileDTO.getSavedFilename()).toString();
+//
+//                ProfileImage newProfileImage = ProfileImage.buildProfileImage(
+//                        fileDTO.getOriginalFilename(),
+//                        fileDTO.getSavedFilename(),
+//                        awsS3URL
+//                );
+//
+//                profileImageRepository.save(newProfileImage);
+//                member.assignProfileImage(newProfileImage);
+//
+//                file.delete();
+
             } catch (IOException e) {
                 throw new ProfileImageSaveException("프로필 이미지를 저장하는 동안 오류가 발생했습니다.");
             }


### PR DESCRIPTION
## #️⃣연관된 이슈

> close  #227 

## 📝작업 내용

- MemberService.java
- updateProfile()에 프로필 이미지 S3 저장 및 삭제 로직 추가

## 💬리뷰 요구사항

> 프로필 이미지 수정 관련 S3 저장 및 삭제 로직을 추가하였습니다.
현재 로컬용, S3용 모두 구현되어 있어 로컬로 테스트 하실 때는 주석 처리 변경 없이 테스트 하시면 되고, S3 테스트는 MemberService의 44번째 줄, 378번째 ~ 400번째 줄 주석 해제 -> 364번째~ 376번째 주석 처리 하시고 테스트 진행하시면 됩니다.
유저 프로필 수정 전 비밀번호 검증은 이미 태현님께서 작성하신 API가 있어 그대로 사용하여 진행되니 참고하시고 확인부탁드립니다!