### PR TITLE
[Refactor: 일반 로그인 사용자와 소셜 로그인 사용자의 구분을 위한 리팩토링

### DIFF
--- a/src/main/java/sumcoda/boardbuddy/dto/MemberResponse.java
+++ b/src/main/java/sumcoda/boardbuddy/dto/MemberResponse.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import sumcoda.boardbuddy.enumerate.MemberType;
 
 import java.util.List;
 import java.util.Map;
@@ -28,16 +29,20 @@ public class MemberResponse {
 
         private Boolean isPhoneNumberVerified;
 
+        private MemberType memberType;
+
         private String profileImageS3SavedURL;
 
+
         @Builder
-        public ProfileDTO(String nickname, String sido, String sgg, String emd, String phoneNumber, Boolean isPhoneNumberVerified, String profileImageS3SavedURL) {
+        public ProfileDTO(String nickname, String sido, String sgg, String emd, String phoneNumber, Boolean isPhoneNumberVerified, MemberType memberType, String profileImageS3SavedURL) {
             this.nickname = nickname;
             this.sido = sido;
             this.sgg = sgg;
             this.emd = emd;
             this.phoneNumber = phoneNumber;
             this.isPhoneNumberVerified = isPhoneNumberVerified;
+            this.memberType = memberType;
             this.profileImageS3SavedURL = profileImageS3SavedURL;
         }
     }

--- a/src/main/java/sumcoda/boardbuddy/entity/Member.java
+++ b/src/main/java/sumcoda/boardbuddy/entity/Member.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import sumcoda.boardbuddy.enumerate.MemberType;
 import sumcoda.boardbuddy.enumerate.Role;
 
 import java.util.ArrayList;
@@ -130,6 +131,10 @@ public class Member {
     // 랭킹 산정을 위한 점수
     private Double rankScore;
 
+    // ex) REGULAR, SOCIAL
+    @Column(nullable = false)
+    private MemberType memberType;
+
     // 사용자의 권한을 나타내기위한 role
     // ex) ADMIN, USER
     @Column(nullable = false)
@@ -163,7 +168,7 @@ public class Member {
     private List<BadgeImage> badgeImages = new ArrayList<>();
 
     @Builder
-    public Member(String username, String password, String nickname, String email, String phoneNumber, String sido, String sgg, String emd, Integer radius, Double buddyScore, Integer joinCount, Integer monthlyExcellentCount, Integer totalExcellentCount, Integer monthlyGoodCount, Integer totalGoodCount, Integer monthlyBadCount, Integer totalBadCount, Integer monthlyNoShowCount, Integer monthlySendReviewCount, String description, Integer rank, Double rankScore, Role role, ProfileImage profileImage) {
+    public Member(String username, String password, String nickname, String email, String phoneNumber, String sido, String sgg, String emd, Integer radius, Double buddyScore, Integer joinCount, Integer monthlyExcellentCount, Integer totalExcellentCount, Integer monthlyGoodCount, Integer totalGoodCount, Integer monthlyBadCount, Integer totalBadCount, Integer monthlyNoShowCount, Integer monthlySendReviewCount, String description, Integer rank, Double rankScore, MemberType memberType, Role role, ProfileImage profileImage) {
         this.username = username;
         this.password = password;
         this.nickname = nickname;
@@ -186,12 +191,13 @@ public class Member {
         this.description = description;
         this.rank = rank;
         this.rankScore = rankScore;
+        this.memberType = memberType;
         this.role = role;
         this.assignProfileImage(profileImage);
     }
 
     // 직접 빌더 패턴의 생성자를 활용하지 말고 해당 메서드를 활용하여 엔티티 생성
-    public static Member buildMember(String username, String password, String nickname, String email, String phoneNumber, String sido, String sgg, String emd, Integer radius, Double buddyScore, Integer joinCount, Integer monthlyExcellentCount, Integer totalExcellentCount, Integer monthlyGoodCount, Integer totalGoodCount, Integer monthlyBadCount, Integer totalBadCount, Integer monthlyNoShowCount, Integer monthlySendReviewCount, String description, Integer rank, Double rankScore, Role role, ProfileImage profileImage) {
+    public static Member buildMember(String username, String password, String nickname, String email, String phoneNumber, String sido, String sgg, String emd, Integer radius, Double buddyScore, Integer joinCount, Integer monthlyExcellentCount, Integer totalExcellentCount, Integer monthlyGoodCount, Integer totalGoodCount, Integer monthlyBadCount, Integer totalBadCount, Integer monthlyNoShowCount, Integer monthlySendReviewCount, String description, Integer rank, Double rankScore, MemberType memberType, Role role, ProfileImage profileImage) {
         return Member.builder()
                 .username(username)
                 .password(password)
@@ -215,6 +221,7 @@ public class Member {
                 .description(description)
                 .rank(rank)
                 .rankScore(rankScore)
+                .memberType(memberType)
                 .role(role)
                 .profileImage(profileImage)
                 .build();

--- a/src/main/java/sumcoda/boardbuddy/enumerate/MemberType.java
+++ b/src/main/java/sumcoda/boardbuddy/enumerate/MemberType.java
@@ -1,0 +1,16 @@
+package sumcoda.boardbuddy.enumerate;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberType {
+
+    REGULAR("regular"),
+    SOCIAL("social");
+
+    @JsonValue
+    private final String value;
+}

--- a/src/main/java/sumcoda/boardbuddy/handler/auth/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/sumcoda/boardbuddy/handler/auth/CustomAuthenticationSuccessHandler.java
@@ -13,6 +13,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 import sumcoda.boardbuddy.dto.MemberResponse;
+import sumcoda.boardbuddy.enumerate.MemberType;
 import sumcoda.boardbuddy.exception.auth.AuthenticationMissingException;
 import sumcoda.boardbuddy.repository.member.MemberRepository;
 
@@ -53,6 +54,7 @@ public class CustomAuthenticationSuccessHandler implements AuthenticationSuccess
                 .sgg(profileDTO.getSgg())
                 .emd(profileDTO.getEmd())
                 .isPhoneNumberVerified(profileDTO.getPhoneNumber() != null)
+                .memberType(profileDTO.getMemberType())
                 .profileImageS3SavedURL(profileDTO.getProfileImageS3SavedURL())
                 .build();
 

--- a/src/main/java/sumcoda/boardbuddy/repository/member/MemberRepositoryCustomImpl.java
+++ b/src/main/java/sumcoda/boardbuddy/repository/member/MemberRepositoryCustomImpl.java
@@ -44,6 +44,7 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
                         member.sgg,
                         member.emd,
                         member.phoneNumber,
+                        member.memberType,
                         profileImage.profileImageS3SavedURL
                 ))
                 .from(member)

--- a/src/main/java/sumcoda/boardbuddy/service/AuthService.java
+++ b/src/main/java/sumcoda/boardbuddy/service/AuthService.java
@@ -135,6 +135,7 @@ public class AuthService {
                 .sgg(profileDTO.getSgg())
                 .emd(profileDTO.getEmd())
                 .isPhoneNumberVerified(profileDTO.getPhoneNumber() != null)
+                .memberType(profileDTO.getMemberType())
                 .profileImageS3SavedURL(profileDTO.getProfileImageS3SavedURL())
                 .build();
     }

--- a/src/main/java/sumcoda/boardbuddy/service/CustomOAuth2UserService.java
+++ b/src/main/java/sumcoda/boardbuddy/service/CustomOAuth2UserService.java
@@ -10,6 +10,7 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import sumcoda.boardbuddy.dto.auth.oauth2.*;
 import sumcoda.boardbuddy.entity.Member;
+import sumcoda.boardbuddy.enumerate.MemberType;
 import sumcoda.boardbuddy.enumerate.Role;
 import sumcoda.boardbuddy.exception.auth.ClientRegistrationRetrievalException;
 import sumcoda.boardbuddy.exception.auth.SocialUserInfoRetrievalException;
@@ -77,32 +78,33 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         // 만약 신규 로그인 회원이라면
         if (findMember == null) {
-            Member member = Member.builder()
-                    .username(username)
-                    .password(bCryptPasswordEncoder.encode(oAuth2UserInfo.getEmail()))
-                    .nickname(oAuth2UserInfo.getName() + randomNumber)
-                    .email(oAuth2UserInfo.getEmail())
-                    .phoneNumber(null)
-                    .sido(null)
-                    .sgg(null)
-                    .emd(null)
-                    .radius(2)
-                    .buddyScore(50.0)
-                    .joinCount(0)
-                    .monthlyExcellentCount(0)
-                    .totalExcellentCount(0)
-                    .monthlyGoodCount(0)
-                    .totalGoodCount(0)
-                    .monthlyBadCount(0)
-                    .totalBadCount(0)
-                    .monthlyNoShowCount(0)
-                    .monthlySendReviewCount(0)
-                    .description(null)
-                    .rank(null)
-                    .rankScore(0.0)
-                    .role(Role.USER)
-                    .profileImage(null)
-                    .build();
+            Member member = Member.buildMember(
+                    username,
+                    bCryptPasswordEncoder.encode(oAuth2UserInfo.getEmail()),
+                    oAuth2UserInfo.getName() + randomNumber,
+                    oAuth2UserInfo.getEmail(),
+                    null,
+                    null,
+                    null,
+                    null,
+                    2,
+                    50.0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    null,
+                    null,
+                    0.0,
+                    MemberType.SOCIAL,
+                    Role.USER,
+                    null
+            );
 
             memberRepository.save(member);
 

--- a/src/main/java/sumcoda/boardbuddy/service/MemberService.java
+++ b/src/main/java/sumcoda/boardbuddy/service/MemberService.java
@@ -9,6 +9,7 @@ import org.springframework.web.multipart.MultipartFile;
 import sumcoda.boardbuddy.dto.*;
 import sumcoda.boardbuddy.entity.Member;
 import sumcoda.boardbuddy.entity.ProfileImage;
+import sumcoda.boardbuddy.enumerate.MemberType;
 import sumcoda.boardbuddy.enumerate.Role;
 import sumcoda.boardbuddy.exception.member.*;
 import sumcoda.boardbuddy.exception.publicDistrict.PublicDistrictRetrievalException;
@@ -108,6 +109,7 @@ public class MemberService {
                 null,
                 null,
                 0.0,
+                MemberType.REGULAR,
                 Role.USER,
                 null)).getId();
 
@@ -156,6 +158,7 @@ public class MemberService {
                 null,
                 null,
                 0.0,
+                MemberType.REGULAR,
                 Role.USER,
                 null)
         );


### PR DESCRIPTION
## #️⃣연관된 이슈

> 이슈번호: #234 
## 📝작업 내용

> 일반 로그인 사용자와 소셜 로그인 사용자의 구분을 위한 리팩토링

- MemberType.java
  - 로그인 사용자의 타입 구분하여 관리하기 위한 Enumerate 클래스 생성
  - 열거형 상수 필드: REGULAR("regular"), SOCIAL("social")
  - 필드 value

- Member.java
  - memberType 필드 추가
  - 생성자 및 buildMember() 메서드 수정

- MemberResponse.ProfileDTO.java
  - memberType 필드 추가

- MemberRepositoryCustomImpl.java
  - findMemberDTOByUsername() 메서드 쿼리 수정

- MemberService.java
  - registerMember(), createAdminAccount() 메서드 내에 memberType 필드 추가로 인한 로직 수정

- CustomOAuth2UserService.java
  - loadUser() 메서드 내에 소셜 로그인 사용자 생성시 파라미터 추가

- CustomAuthenticationSuccessHandler.java
  - onAuthenticationSuccess() 매서드 내에 로그인에 성공시 클라이언트로 전달하기 위한 사용자의 정보 추가

- AuthService.java
  - isAuthenticated() 메서드 내에 클라이언트가 사용자의 로그인 상태를 확인시 전달하는 사용자의 정보 추가
---
## 💬리뷰 요구사항
- 일반 로그인 사용자와 소셜 로그인 사용자의 구분을 위한 리팩토링입니다.