### PR TITLE
[Refactor/#244] 모집글 검색 기능 정렬 기준 수정

### DIFF
--- a/src/main/java/sumcoda/boardbuddy/repository/gatherArticle/GatherArticleRepositoryCustomImpl.java
+++ b/src/main/java/sumcoda/boardbuddy/repository/gatherArticle/GatherArticleRepositoryCustomImpl.java
@@ -312,7 +312,7 @@ public class GatherArticleRepositoryCustomImpl implements GatherArticleRepositor
                         eqMemberGatherArticleRole(role),
                         titleOrDescriptionContains(keyword)
                 )
-                .orderBy(gatherArticle.createdAt.desc())
+                .orderBy(gatherArticle.id.desc())
                 .fetch();
 
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #244 

## 📝작업 내용

> 모집글 검색 기능 정렬 기준 수정
- 기존: gatherArticle.createdAt 내림차순 -> 수정: gatherArticle.id 내림차순
