### PR TITLE
[Refactor/#250] 프로필 조회 시 뱃지 부분 응답 수정

### DIFF
--- a/src/main/java/sumcoda/boardbuddy/dto/MemberResponse.java
+++ b/src/main/java/sumcoda/boardbuddy/dto/MemberResponse.java
@@ -71,7 +71,7 @@ public class MemberResponse {
 
         private Double buddyScore;
 
-        private List<String> badges;
+        private List<BadgeImageResponse.BadgeImageInfosDTO> badges;
 
         private Integer joinCount;
 
@@ -82,7 +82,7 @@ public class MemberResponse {
         private Integer totalBadCount;
 
         @Builder(toBuilder = true)
-        public ProfileInfosDTO(String profileImageS3SavedURL, String description, Integer rank, Double buddyScore, List<String> badges, Integer joinCount, Integer totalExcellentCount, Integer totalGoodCount, Integer totalBadCount) {
+        public ProfileInfosDTO(String profileImageS3SavedURL, String description, Integer rank, Double buddyScore, List<BadgeImageResponse.BadgeImageInfosDTO> badges, Integer joinCount, Integer totalExcellentCount, Integer totalGoodCount, Integer totalBadCount) {
             this.profileImageS3SavedURL = profileImageS3SavedURL;
             this.description = description;
             this.rank = rank;

--- a/src/main/java/sumcoda/boardbuddy/repository/member/MemberRepositoryCustomImpl.java
+++ b/src/main/java/sumcoda/boardbuddy/repository/member/MemberRepositoryCustomImpl.java
@@ -5,6 +5,7 @@ import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import sumcoda.boardbuddy.dto.AuthResponse;
+import sumcoda.boardbuddy.dto.BadgeImageResponse;
 import sumcoda.boardbuddy.dto.MemberResponse;
 import sumcoda.boardbuddy.entity.Member;
 
@@ -78,7 +79,10 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
 
     @Override
     public Optional<MemberResponse.ProfileInfosDTO> findMemberProfileByNickname(String nickname) {
-        List<String> badges = jpaQueryFactory.select(badgeImage.badgeImageS3SavedURL)
+        List<BadgeImageResponse.BadgeImageInfosDTO> badges = jpaQueryFactory.select(
+                Projections.fields(BadgeImageResponse.BadgeImageInfosDTO.class,
+                        badgeImage.badgeImageS3SavedURL,
+                        badgeImage.badgeYearMonth))
                 .from(badgeImage)
                 .leftJoin(badgeImage.member, member)
                 .where(member.nickname.eq(nickname))


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #250

## 📝작업 내용
- MemberResponse.java
  - ProfileInfosDTO()에 뱃지 타입을 List<BadgeImageResponse.BadgeImageInfosDTO>로 수정

- MemberRepositoryCustomImpl.java
  - findMemberProfileByNickname() 수정

## 💬리뷰 요구사항

> 프로필 조회 시 뱃지 부분 응답에 날짜도 같이 반환하도록 수정하였습니다.