### PR TITLE
Fix: Next.js (/api/...) 라우팅 이슈로 인한 수정

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -15,8 +15,8 @@ server {
 
     ssl_certificate /etc/letsencrypt/live/boardbuddyapp.com/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/boardbuddyapp.com/privkey.pem;
-#     ssl_protocols TLSv1.2 TLSv1.3; # 안전하지 않은 구식 프로토콜을 차단하여 서버와 클라이언트 간의 연결이 최신 보안 표준을 따름
-#     ssl_ciphers HIGH:!aNULL:!MD5; # 안전하지 않은 암호화 알고리즘을 제거하여 서버의 보안을 강화하고 강력한 암호화와 해시 알고리즘만 사용하도록 제한
+    ssl_protocols TLSv1.2 TLSv1.3; # 안전하지 않은 구식 프로토콜을 차단하여 서버와 클라이언트 간의 연결이 최신 보안 표준을 따름
+    ssl_ciphers HIGH:!aNULL:!MD5; # 안전하지 않은 암호화 알고리즘을 제거하여 서버의 보안을 강화하고 강력한 암호화와 해시 알고리즘만 사용하도록 제한
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
@@ -28,7 +28,7 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    location /api {
+    location /v1 {
         proxy_pass http://127.0.0.1:8080;  # 백엔드 애플리케이션이 실행 중인 포트
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -37,7 +37,7 @@ server {
         proxy_cookie_path / "/; Secure; HttpOnly; SameSite=None";   # 쿠키 설정
     }
 
-    location /api/ws-stomp {
+    location /v1/ws-stomp {
         proxy_pass http://127.0.0.1:8080;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -51,7 +51,7 @@ server {
         proxy_set_header Origin "";
     }
 
-    location /api/notifications/subscribe {
+    location /v1/notifications/subscribe {
         proxy_pass http://127.0.0.1:8080;
         proxy_http_version 1.1;
         proxy_read_timeout 86400s;

--- a/src/main/java/sumcoda/boardbuddy/config/SecurityConfig.java
+++ b/src/main/java/sumcoda/boardbuddy/config/SecurityConfig.java
@@ -102,15 +102,15 @@ public class SecurityConfig {
                         .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
                         .requestMatchers(
                                 // 로그인 하지 않은 사용자라도 요청을 보낼 수 있는 API Path
-                                "/api/auth/register",
-                                "/api/auth/username/check",
-                                "/api/auth/nickname/check",
-                                "/api/auth/sms-certifications/send",
-                                "/api/auth/sms-certifications/verify",
-                                "/api/auth/login",
-                                "/api/oauth2/**",
-                                "/api/login/oauth2/code/**",
-                                "/api/auth/locations/search"
+                                "/v1/auth/register",
+                                "/v1/auth/username/check",
+                                "/v1/auth/nickname/check",
+                                "/v1/auth/sms-certifications/send",
+                                "/v1/auth/sms-certifications/verify",
+                                "/v1/auth/login",
+                                "/v1/oauth2/**",
+                                "/v1/login/oauth2/code/**",
+                                "/v1/auth/locations/search"
                         ).permitAll()
                         // 단순히 로그인한 인증 여부만 확인
 //                        .anyRequest().authenticated()
@@ -139,9 +139,9 @@ public class SecurityConfig {
                 .oauth2Login(oauth2 -> oauth2
 //                        .loginPage("/auth/login")
                         .authorizationEndpoint(oAuth2 -> oAuth2
-                                .baseUri("/api/oauth2/authorization"))
+                                .baseUri("/v1/oauth2/authorization"))
                         .redirectionEndpoint(oAuth2 -> oAuth2
-                                .baseUri("/api/login/oauth2/code/**"))
+                                .baseUri("/v1/login/oauth2/code/**"))
                         .userInfoEndpoint(userInfoEndpointConfig ->
                                 userInfoEndpointConfig
                                         .userService(customOAuth2UserService))
@@ -149,7 +149,7 @@ public class SecurityConfig {
                         .failureHandler(oAuth2AuthenticationFailureHandler));
 
         http.logout(auth -> auth
-                .logoutUrl("/api/auth/logout")
+                .logoutUrl("/v1/auth/logout")
                 .logoutSuccessHandler(customLogoutSuccessHandler)
                 .deleteCookies("JSESSIONID"));
 

--- a/src/main/java/sumcoda/boardbuddy/config/WebMvcConfig.java
+++ b/src/main/java/sumcoda/boardbuddy/config/WebMvcConfig.java
@@ -18,23 +18,24 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(authenticationInterceptor)
-                .addPathPatterns("/api/**")
+                .addPathPatterns("/v1/**")
                 .excludePathPatterns(List.of(
-                        "/api/auth/register",
-                        "/api/auth/username/check",
-                        "/api/auth/nickname/check",
-                        "/api/auth/sms-certifications/send",
-                        "/api/auth/sms-certifications/verify",
-                        "/api/auth/login",
-                        "/api/oauth2/**",
-                        "/api/login/oauth2/code/**",
-                        "/api/auth/locations/search",
-                        "/api/rankings",
-                        "/api/ws-stomp/**"
+                        "/v1/auth/register",
+                        "/v1/auth/username/check",
+                        "/v1/auth/nickname/check",
+                        "/v1/auth/sms-certifications/send",
+                        "/v1/auth/sms-certifications/verify",
+                        "/v1/auth/login",
+                        "/v1/oauth2/**",
+                        "/v1/login/oauth2/code/**",
+                        "/v1/auth/locations/search",
+                        "/v1/rankings",
+                        "/v1/ws-stomp/**"
                 ));
         WebMvcConfigurer.super.addInterceptors(registry);
     }
 
+    // 로컬 테스트용 저장공간 설정
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
 

--- a/src/main/java/sumcoda/boardbuddy/config/WebsocketConfig.java
+++ b/src/main/java/sumcoda/boardbuddy/config/WebsocketConfig.java
@@ -17,9 +17,9 @@ public class WebsocketConfig implements WebSocketMessageBrokerConfigurer {
      **/
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
-      registry.setApplicationDestinationPrefixes("/api/ws-stomp/publication");
+      registry.setApplicationDestinationPrefixes("/v1/ws-stomp/publication");
 
-      registry.enableSimpleBroker("/api/ws-stomp/reception");
+      registry.enableSimpleBroker("/v1/ws-stomp/reception");
     }
 
     /**
@@ -29,7 +29,7 @@ public class WebsocketConfig implements WebSocketMessageBrokerConfigurer {
      **/
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-      registry.addEndpoint("/api/ws-stomp/connection")
+      registry.addEndpoint("/v1/ws-stomp/connection")
               .setAllowedOriginPatterns("*");
 //              .withSockJS();
     }

--- a/src/main/java/sumcoda/boardbuddy/controller/AuthController.java
+++ b/src/main/java/sumcoda/boardbuddy/controller/AuthController.java
@@ -31,7 +31,7 @@ public class AuthController {
      * @param sendSMSCertificationDTO 로그인 정보를 포함하는 사용자 객체
      * @return 인증번호가 성공적으로 전달되었다면 약속된 SuccessResponse 반환
      **/
-    @PostMapping("/api/auth/sms-certifications/send")
+    @PostMapping("/v1/auth/sms-certifications/send")
     public ResponseEntity<ApiResponse<Void>> sendSMS(@RequestBody AuthRequest.SendSMSCertificationDTO sendSMSCertificationDTO) {
         log.info("send sms is working");
 
@@ -46,7 +46,7 @@ public class AuthController {
      * @param validateSMSCertificationDTO 인증번호 확인을 요청한 사용자의 핸드폰 번호가 저장되어있는 DTO
      * @return 인증 번호가 올바르게 입력되었다면 약속된 SuccessResponse 반환
      **/
-    @PostMapping("/api/auth/sms-certifications/verify")
+    @PostMapping("/v1/auth/sms-certifications/verify")
     public ResponseEntity<ApiResponse<Void>> verifyCertificationNumber(@RequestBody AuthRequest.ValidateSMSCertificationDTO validateSMSCertificationDTO) {
         log.info("validate certification is working");
 
@@ -61,7 +61,7 @@ public class AuthController {
      * @param username 로그인 사용자 아이디
      * @return 사용자가 로그인한 상태라면 해당 사용자의 프로필을 기반으로한 약속된 SuccessResponse 반환
      **/
-    @GetMapping("/api/auth/status")
+    @GetMapping("/v1/auth/status")
     public ResponseEntity<ApiResponse<Map<String, MemberResponse.ProfileDTO>>> isAuthenticated(@RequestAttribute String username) {
         log.info("check session is working");
 
@@ -77,7 +77,7 @@ public class AuthController {
      * @param username 로그인 사용자 아이디
      * @return 사용자가 비밀번호 검증에 성공했다면 약속된 SuccessResponse 반환
      **/
-    @PostMapping("/api/auth/password")
+    @PostMapping("/v1/auth/password")
     public ResponseEntity<ApiResponse<Void>> validatePassword(
             @RequestBody AuthRequest.ValidatePasswordDTO validatePasswordDTO,
             @RequestAttribute String username) {

--- a/src/main/java/sumcoda/boardbuddy/controller/BadgeImageController.java
+++ b/src/main/java/sumcoda/boardbuddy/controller/BadgeImageController.java
@@ -29,7 +29,7 @@ public class BadgeImageController {
      * @param nickname 유저 닉네임
      * @return 뱃지 리스트
      **/
-    @GetMapping(value = "/api/badges/{nickname}")
+    @GetMapping(value = "/v1/badges/{nickname}")
     public ResponseEntity<ApiResponse<Map<String, List<BadgeImageResponse.BadgeImageInfosDTO>>>> getBadges (@PathVariable String nickname) {
         log.info("get badges is working");
 

--- a/src/main/java/sumcoda/boardbuddy/controller/BoardCafeController.java
+++ b/src/main/java/sumcoda/boardbuddy/controller/BoardCafeController.java
@@ -33,7 +33,7 @@ public class BoardCafeController {
      * @param username 사용자 이름
      * @return 보드게임 카페 리스트
      */
-    @GetMapping("/api/board-cafes")
+    @GetMapping("/v1/board-cafes")
     public ResponseEntity<ApiResponse<Map<String, List<BoardCafeResponse.InfoDTO>>>> getBoardCafes(
             @RequestParam Double x,
             @RequestParam Double y,

--- a/src/main/java/sumcoda/boardbuddy/controller/ChatMessageController.java
+++ b/src/main/java/sumcoda/boardbuddy/controller/ChatMessageController.java
@@ -48,7 +48,7 @@ public class ChatMessageController {
      * @param username 요청을 보낸 사용자 아이디
      * @return 채팅방 메세지 내역
      */
-    @GetMapping("/api/chat/rooms/{chatRoomId}/messages")
+    @GetMapping("/v1/chat/rooms/{chatRoomId}/messages")
     public ResponseEntity<ApiResponse<Map<String, List<ChatMessageResponse.ChatMessageInfoDTO>>>> getChatMessages(
             @PathVariable Long chatRoomId,
             @RequestAttribute String username) {

--- a/src/main/java/sumcoda/boardbuddy/controller/ChatRoomController.java
+++ b/src/main/java/sumcoda/boardbuddy/controller/ChatRoomController.java
@@ -33,7 +33,7 @@ public class ChatRoomController {
      * @param gatherArticleId 모집글 Id
      * @return 채팅방과 연관된 모집글 정보
      **/
-    @GetMapping("/api/chat/rooms/{chatRoomId}/gather-articles/{gatherArticleId}")
+    @GetMapping("/v1/chat/rooms/{chatRoomId}/gather-articles/{gatherArticleId}")
     public ResponseEntity<ApiResponse<Map<String, GatherArticleResponse.SummaryInfoDTO>>> getChatRoomGatherArticleInfo(@PathVariable Long chatRoomId,
                                                                                                                        @PathVariable Long gatherArticleId,
                                                                                                                        @RequestAttribute String username) {
@@ -49,7 +49,7 @@ public class ChatRoomController {
      * @param username 조회하려는 사용자의 아이디
      * @return 사용자가 참여한 채팅방 목록
      */
-    @GetMapping("/api/chat/rooms")
+    @GetMapping("/v1/chat/rooms")
     public ResponseEntity<ApiResponse<Map<String, List<ChatRoomResponse.ChatRoomDetailsDTO>>>> getChatRoomDetailsByUsername(@RequestAttribute String username) {
         List<ChatRoomResponse.ChatRoomDetailsDTO> chatRoomDetailsList = chatRoomService.getChatRoomDetailsListByUsername(username);
 

--- a/src/main/java/sumcoda/boardbuddy/controller/CommentController.java
+++ b/src/main/java/sumcoda/boardbuddy/controller/CommentController.java
@@ -35,7 +35,7 @@ public class CommentController {
      * @param username        사용자 이름
      * @return 성공 응답
      */
-    @PostMapping(value = {"/api/gather-articles/{gatherArticleId}/comments", "/api/gather-articles/{gatherArticleId}/comments/{parentId}"})
+    @PostMapping(value = {"/v1/gather-articles/{gatherArticleId}/comments", "/v1/gather-articles/{gatherArticleId}/comments/{parentId}"})
     public ResponseEntity<ApiResponse<Void>> createComment(
             @PathVariable Long gatherArticleId,
             @PathVariable(required = false) Long parentId,
@@ -57,7 +57,7 @@ public class CommentController {
      * @param username        사용자 이름
      * @return 댓글 리스트 응답
      */
-    @GetMapping("/api/gather-articles/{gatherArticleId}/comments")
+    @GetMapping("/v1/gather-articles/{gatherArticleId}/comments")
     public ResponseEntity<ApiResponse<Map<String, List<CommentResponse.InfoDTO>>>> getComments(
             @PathVariable Long gatherArticleId,
             @RequestAttribute String username) {
@@ -77,7 +77,7 @@ public class CommentController {
      * @param username        사용자 이름
      * @return 성공 응답
      */
-    @PutMapping("/api/gather-articles/{gatherArticleId}/comments/{commentId}")
+    @PutMapping("/v1/gather-articles/{gatherArticleId}/comments/{commentId}")
     public ResponseEntity<ApiResponse<Void>> updateComment(
             @PathVariable Long gatherArticleId,
             @PathVariable Long commentId,
@@ -98,7 +98,7 @@ public class CommentController {
      * @param username        사용자 이름
      * @return 성공 응답
      */
-    @DeleteMapping("/api/gather-articles/{gatherArticleId}/comments/{commentId}")
+    @DeleteMapping("/v1/gather-articles/{gatherArticleId}/comments/{commentId}")
     public ResponseEntity<ApiResponse<Void>> deleteComment(
             @PathVariable Long gatherArticleId,
             @PathVariable Long commentId,

--- a/src/main/java/sumcoda/boardbuddy/controller/GatherArticleController.java
+++ b/src/main/java/sumcoda/boardbuddy/controller/GatherArticleController.java
@@ -41,7 +41,7 @@ public class GatherArticleController {
      * @param username          모집글 작성자 아이디
      * @return                  생성된 모집글과 관련된 응답 데이터
      */
-    @PostMapping(value = "/api/gather-articles")
+    @PostMapping(value = "/v1/gather-articles")
     public ResponseEntity<ApiResponse<Map<String, GatherArticleResponse.CreateDTO>>> createGatherArticle(
             @RequestBody GatherArticleRequest.CreateDTO createRequest,
             @RequestAttribute String username){
@@ -71,7 +71,7 @@ public class GatherArticleController {
      * @param username          사용자 username
      * @return                  조회된 모집글과 관련된 응답 데이터
      */
-    @GetMapping(value = "/api/gather-articles/{gatherArticleId}")
+    @GetMapping(value = "/v1/gather-articles/{gatherArticleId}")
     public ResponseEntity<ApiResponse<Map<String, GatherArticleResponse.ReadDTO>>> getGatherArticle(
             @PathVariable Long gatherArticleId,
             @RequestAttribute String username) {
@@ -87,7 +87,7 @@ public class GatherArticleController {
      * @param username          사용자 username
      * @return                  수정된 모집글과 관련된 응답 데이터
      */
-    @PutMapping(value = "/api/gather-articles/{gatherArticleId}")
+    @PutMapping(value = "/v1/gather-articles/{gatherArticleId}")
     public ResponseEntity<ApiResponse<Map<String, GatherArticleResponse.UpdateDTO>>> updateGatherArticle(
             @PathVariable Long gatherArticleId,
             @RequestBody GatherArticleRequest.UpdateDTO updateRequest,
@@ -103,7 +103,7 @@ public class GatherArticleController {
      * @param username          사용자 username
      * @return                  삭제된 모집글과 관련된 응답 데이터
      */
-    @DeleteMapping(value = "/api/gather-articles/{gatherArticleId}")
+    @DeleteMapping(value = "/v1/gather-articles/{gatherArticleId}")
     public ResponseEntity<ApiResponse<Map<String, GatherArticleResponse.DeleteDTO>>> deleteGatherArticle(
             @PathVariable Long gatherArticleId,
             @RequestAttribute String username){
@@ -117,7 +117,7 @@ public class GatherArticleController {
      * @param username 사용자 username
      * @return 내가 작성한 모집글 리스트
      **/
-    @GetMapping(value = "/api/my/gather-articles")
+    @GetMapping(value = "/v1/my/gather-articles")
     public ResponseEntity<ApiResponse<Map<String, List<GatherArticleResponse.GatherArticleInfosDTO>>>> getMyGatherArticles (
             @RequestAttribute String username) {
         log.info("get gather articles is working");
@@ -133,7 +133,7 @@ public class GatherArticleController {
      * @param username 사용자 username
      * @return 참가한 모집글 리스트
      **/
-    @GetMapping(value = "/api/my/participations")
+    @GetMapping(value = "/v1/my/participations")
     public ResponseEntity<ApiResponse<Map<String, List<GatherArticleResponse.MyParticipationInfosDTO>>>> getMyParticipations (
             @RequestAttribute String username) {
         log.info("get my participations is working");
@@ -152,7 +152,7 @@ public class GatherArticleController {
      * @param username 사용자 이름
      * @return 모집글 리스트
      */
-    @GetMapping("/api/gather-articles")
+    @GetMapping("/v1/gather-articles")
     public ResponseEntity<ApiResponse<GatherArticleResponse.ReadListDTO>> getGatherArticles(
             @RequestParam Integer page,
             @RequestParam(required = false) String status,
@@ -172,7 +172,7 @@ public class GatherArticleController {
      * @param username  사용자 username
      * @return          검색 결과 리스트
      */
-    @GetMapping("/api/gather-articles/search")
+    @GetMapping("/v1/gather-articles/search")
     public ResponseEntity<ApiResponse<Map<String, List<GatherArticleResponse.SearchResultDTO>>>> searchArticles(
             @RequestParam String query,
             @RequestAttribute String username) {

--- a/src/main/java/sumcoda/boardbuddy/controller/MemberController.java
+++ b/src/main/java/sumcoda/boardbuddy/controller/MemberController.java
@@ -29,7 +29,7 @@ public class MemberController {
      * @param verifyUsernameDuplicationDTO 사용자가 입력한 아이디
      * @return 아이디가 중복되지 않았다면 약속된 SuccessResponse 반환
      **/
-    @PostMapping(value = "/api/auth/username/check")
+    @PostMapping(value = "/v1/auth/username/check")
     public ResponseEntity<ApiResponse<Void>> verifyUsernameDuplication(
             @RequestBody MemberRequest.VerifyUsernameDuplicationDTO verifyUsernameDuplicationDTO) {
         log.info("verify username duplication is working");
@@ -45,7 +45,7 @@ public class MemberController {
      * @param verifyNicknameDuplicationDTO 사용자가 입력한 닉네임
      * @return 닉네임이 중복되지 않았다면 약속된 SuccessResponse 반환
      **/
-    @PostMapping(value = "/api/auth/nickname/check")
+    @PostMapping(value = "/v1/auth/nickname/check")
     public ResponseEntity<ApiResponse<Void>> verifyNicknameDuplication(
             @RequestBody MemberRequest.VerifyNicknameDuplicationDTO verifyNicknameDuplicationDTO) {
         log.info("verify nickname duplication is working");
@@ -61,7 +61,7 @@ public class MemberController {
      * @param registerDTO 프론트로부터 전달받은 회원가입 정보
      * @return 회원가입에 성공했다면약속된 SuccessResponse 반환
      **/
-    @PostMapping(value = "/api/auth/register")
+    @PostMapping(value = "/v1/auth/register")
     public ResponseEntity<ApiResponse<Void>> register(@RequestBody MemberRequest.RegisterDTO registerDTO) {
         log.info("register is working");
 
@@ -77,7 +77,7 @@ public class MemberController {
      * @param username 소셜 로그인 사용자 아이디
      * @return 첫 소셜 로그인 사용자가 회원가입에 성공했다면 약속된 SuccessResponse 반환
      **/
-    @PostMapping(value = "/api/auth/oauth2/register")
+    @PostMapping(value = "/v1/auth/oauth2/register")
     public ResponseEntity<ApiResponse<Void>> oAuth2Register(@RequestBody MemberRequest.OAuth2RegisterDTO oAuth2RegisterDTO,
                                                             @RequestAttribute String username) {
         log.info("social register is working");
@@ -93,7 +93,7 @@ public class MemberController {
      * @param username 로그인 사용자 아이디
      * @return 회원 탈퇴가 완료되었다면 약속된 SuccessResponse 반환
      **/
-    @PostMapping(value = "/api/auth/withdrawal")
+    @PostMapping(value = "/v1/auth/withdrawal")
     public ResponseEntity<ApiResponse<Void>> withdrawalMember(@RequestAttribute String username) {
         log.info("withdrawal member is working");
 
@@ -108,7 +108,7 @@ public class MemberController {
      * @param username 로그인 사용자 아이디
      * @return 내 동네 조회를 성공했다면 약속된 SuccessResponse 반환
      */
-    @GetMapping("/api/my/neighborhoods")
+    @GetMapping("/v1/my/neighborhoods")
     public ResponseEntity<ApiResponse<MemberResponse.MyLocationsDTO>> getMemberNeighborhoods(@RequestAttribute String username) {
         log.info("getMemberNeighborhoods is working");
 
@@ -123,7 +123,7 @@ public class MemberController {
      * @param locationDTO 사용자가 입력한 위치 정보
      * @return 내 동네 설정을 성공했다면 약속된 SuccessResponse 반환
      **/
-    @PutMapping("/api/my/neighborhoods")
+    @PutMapping("/v1/my/neighborhoods")
     public ResponseEntity<ApiResponse<Map<String, Map<Integer, List<MemberResponse.LocationDTO>>>>> updateMemberNeighborhood(
             @RequestBody MemberRequest.LocationDTO locationDTO,
             @RequestAttribute String username) {
@@ -141,7 +141,7 @@ public class MemberController {
      * @param username 로그인 사용자 아이디
      * @return 내 반경 설정을 성공했다면 약속된 SuccessResponse 반환
      **/
-    @PutMapping("/api/my/radius")
+    @PutMapping("/v1/my/radius")
     public ResponseEntity<ApiResponse<Void>> updateMemberRadius(
             @RequestBody MemberRequest.RadiusDTO radiusDTO,
             @RequestAttribute String username) {
@@ -158,7 +158,7 @@ public class MemberController {
      * @param nickname 유저 닉네임
      * @return 프로필 조회가 성공했다면 약속된 SuccessResponse 반환
      **/
-    @GetMapping("/api/profiles/{nickname}")
+    @GetMapping("/v1/profiles/{nickname}")
     public ResponseEntity<ApiResponse<Map<String, MemberResponse.ProfileInfosDTO>>> getMemberProfileByNickname (@PathVariable String nickname) {
         log.info("get member profile is working");
 
@@ -175,7 +175,7 @@ public class MemberController {
      * @param profileImageFile 수정할 프로필 이미지 파일
      * @return 프로필 조회가 성공했다면 약속된 SuccessResponse 반환
      **/
-    @PutMapping("/api/profiles")
+    @PutMapping("/v1/profiles")
     public ResponseEntity<ApiResponse<Void>> updateProfile(
             @RequestAttribute String username,
             @RequestPart(value = "UpdateProfileDTO") MemberRequest.UpdateProfileDTO updateProfileDTO,

--- a/src/main/java/sumcoda/boardbuddy/controller/NotificationController.java
+++ b/src/main/java/sumcoda/boardbuddy/controller/NotificationController.java
@@ -31,7 +31,7 @@ public class NotificationController {
      * <p>
      * //     * @param nickname 알람 구독 요청 사용자 닉네임
      **/
-    @GetMapping(value = "/api/notifications/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    @GetMapping(value = "/v1/notifications/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public ResponseEntity<SseEmitter> subscribe(
             @RequestAttribute String username
     ) {
@@ -52,7 +52,7 @@ public class NotificationController {
      * @param username 알림 목록 조회 사용자 아이디
      * @return 알림 목록 조회 성공 시 약속된 SuccessResponse 반환
      **/
-    @GetMapping(value = "/api/notifications")
+    @GetMapping(value = "/v1/notifications")
     public ResponseEntity<ApiResponse<Map<String, List<NotificationResponse.NotificationDTO>>>> getNotifications(
             @RequestAttribute String username
     ) {

--- a/src/main/java/sumcoda/boardbuddy/controller/ParticipationApplicationController.java
+++ b/src/main/java/sumcoda/boardbuddy/controller/ParticipationApplicationController.java
@@ -36,7 +36,7 @@ public class ParticipationApplicationController {
      * @param gatherArticleId 모집글 ID
      * @param username 참가신청 요청을 보내는 사용자 아이디
      **/
-    @PostMapping("/api/gather-articles/{gatherArticleId}/participation")
+    @PostMapping("/v1/gather-articles/{gatherArticleId}/participation")
     public ResponseEntity<ApiResponse<Void>> applyParticipation(@PathVariable Long gatherArticleId, @RequestAttribute String username) {
         participationApplicationService.applyParticipation(gatherArticleId, username);
 
@@ -53,7 +53,7 @@ public class ParticipationApplicationController {
      * @param username 승인 요청을 보내는 모집글 작성자 아이디
      * @param applicantNickname 참가 신청을 했던 사용자의 아이디
      **/
-    @PutMapping("/api/gather-articles/{gatherArticleId}/participation/{participationApplicationId}/approval")
+    @PutMapping("/v1/gather-articles/{gatherArticleId}/participation/{participationApplicationId}/approval")
     public ResponseEntity<ApiResponse<Void>> approveParticipationApplication(@PathVariable Long gatherArticleId, @PathVariable Long participationApplicationId, @RequestAttribute String username, @RequestParam String applicantNickname) {
 
         String applicantUsername = participationApplicationService.approveParticipationApplication(gatherArticleId, participationApplicationId, username, applicantNickname);
@@ -77,7 +77,7 @@ public class ParticipationApplicationController {
      * @param username 거절 요청을 보내는 모집글 작성자 아이디
      * @param applicantNickname 참가 신청을 했던 사용자의 아이디
      **/
-    @PutMapping("/api/gather-articles/{gatherArticleId}/participation/{participationApplicationId}/rejection")
+    @PutMapping("/v1/gather-articles/{gatherArticleId}/participation/{participationApplicationId}/rejection")
     public ResponseEntity<ApiResponse<Void>> rejectParticipationApplication(@PathVariable Long gatherArticleId, @PathVariable Long participationApplicationId, @RequestAttribute String username, @RequestParam String applicantNickname) {
 
         participationApplicationService.rejectParticipationApplication(gatherArticleId, participationApplicationId, username);
@@ -93,7 +93,7 @@ public class ParticipationApplicationController {
      * @param gatherArticleId 모집글 Id
      * @param username 참가신청을 취소하는 사용자 아이디
      **/
-    @PutMapping("/api/gather-articles/{gatherArticleId}/participation")
+    @PutMapping("/v1/gather-articles/{gatherArticleId}/participation")
     public ResponseEntity<ApiResponse<Void>> cancelParticipationApplication(@PathVariable Long gatherArticleId, @RequestAttribute String username) {
 
         Boolean isMemberParticipant = participationApplicationService.cancelParticipationApplication(gatherArticleId, username);
@@ -119,7 +119,7 @@ public class ParticipationApplicationController {
      * @param username 참가 신청 목록 조회 요청을 보내는 모집글 작성자 아이디
      * @return 모집글 참가 신청중인 사용자 목록
      **/
-    @GetMapping("/api/gather-articles/{gatherArticleId}/participation")
+    @GetMapping("/v1/gather-articles/{gatherArticleId}/participation")
     public ResponseEntity<ApiResponse<Map<String, List<ParticipationApplicationResponse.InfoDTO>>>> getParticipationAppliedMemberList(@PathVariable Long gatherArticleId, @RequestAttribute String username) {
 
         List<ParticipationApplicationResponse.InfoDTO> participationAppliedMemberList = participationApplicationService.getParticipationAppliedMemberList(gatherArticleId, username);

--- a/src/main/java/sumcoda/boardbuddy/controller/PublicDistrictController.java
+++ b/src/main/java/sumcoda/boardbuddy/controller/PublicDistrictController.java
@@ -27,7 +27,7 @@ public class PublicDistrictController {
      * @param emd 읍면동 검색어
      * @return 검색된 위치 정보 리스트
      */
-    @GetMapping("/api/auth/locations/search")
+    @GetMapping("/v1/auth/locations/search")
     public ResponseEntity<ApiResponse<Map<String, List<PublicDistrictResponse.InfoDTO>>>> searchAuthLocations(@RequestParam String emd) {
         log.info("searchLocations is working: " + emd + "으로 검색하였습니다.");
 
@@ -42,7 +42,7 @@ public class PublicDistrictController {
      * @param emd 읍면동 검색어
      * @return 검색된 위치 정보 리스트
      */
-    @GetMapping("/api/locations/search")
+    @GetMapping("/v1/locations/search")
     public ResponseEntity<ApiResponse<Map<String, List<PublicDistrictResponse.InfoDTO>>>> searchLocations(
             @RequestParam String emd,
             @RequestAttribute String username) {

--- a/src/main/java/sumcoda/boardbuddy/controller/RankingController.java
+++ b/src/main/java/sumcoda/boardbuddy/controller/RankingController.java
@@ -26,7 +26,7 @@ public class RankingController {
      *
      * @return TOP3 리스트를 조회하여 약속된 SuccessResponse 반환
      */
-    @GetMapping("/api/rankings")
+    @GetMapping("/v1/rankings")
     public ResponseEntity<ApiResponse<Map<String, List<MemberResponse.RankingsDTO>>>> getTop3Rankings() {
         List<MemberResponse.RankingsDTO> rankingsDTO = rankingService.getTop3Rankings();
         return buildSuccessResponseWithPairKeyData("rankings", rankingsDTO,"랭킹 조회에 성공했습니다.", HttpStatus.OK);

--- a/src/main/java/sumcoda/boardbuddy/controller/ReviewController.java
+++ b/src/main/java/sumcoda/boardbuddy/controller/ReviewController.java
@@ -30,7 +30,7 @@ public class ReviewController {
      * @param username        로그인 사용자 아이디
      * @return 유저 리스트 조회가 성공했다면 약속된 SuccessResponse 반환
      **/
-    @GetMapping("/api/reviews/{gatherArticleId}")
+    @GetMapping("/v1/reviews/{gatherArticleId}")
     public ResponseEntity<ApiResponse<Map<String, List<ReviewResponse.UserDTO>>>> getParticipatedList (
             @PathVariable Long gatherArticleId,
             @RequestAttribute String username) {
@@ -49,7 +49,7 @@ public class ReviewController {
      * @param username 로그인 사용자 아이디
      * @return 리뷰 보내기가 성공했다면 약속된 SuccessResponse 반환
      **/
-    @PostMapping("/api/reviews/{gatherArticleId}")
+    @PostMapping("/v1/reviews/{gatherArticleId}")
     public ResponseEntity<ApiResponse<Void>> sendReview (
             @PathVariable Long gatherArticleId,
             @RequestBody ReviewRequest.SendDTO sendDTO,

--- a/src/main/java/sumcoda/boardbuddy/filter/CustomAuthenticationFilter.java
+++ b/src/main/java/sumcoda/boardbuddy/filter/CustomAuthenticationFilter.java
@@ -26,7 +26,7 @@ public class CustomAuthenticationFilter extends AbstractAuthenticationProcessing
 
     public CustomAuthenticationFilter() {
         // url과 일치할 경우 해당 필터가 동작합니다.
-        super(new AntPathRequestMatcher("/api/auth/login"));
+        super(new AntPathRequestMatcher("/v1/auth/login"));
     }
 
     // 요청으로 받은 유저 정보를 바탕으로 로그인 인증 시도

--- a/src/main/java/sumcoda/boardbuddy/service/ChatMessageService.java
+++ b/src/main/java/sumcoda/boardbuddy/service/ChatMessageService.java
@@ -72,7 +72,7 @@ public class ChatMessageService {
         ChatMessageResponse.ChatMessageInfoDTO responseChatMessage = chatMessageRepository.findTalkMessageById(chatMessageId)
                 .orElseThrow(() -> new ChatMessageRetrievalException("서버 문제로 해당 메세지를 찾을 수 없습니다. 관리자에게 문의하세요."));
 
-        messagingTemplate.convertAndSend("/api/ws-stomp/reception/" + chatRoomId, responseChatMessage);
+        messagingTemplate.convertAndSend("/v1/ws-stomp/reception/" + chatRoomId, responseChatMessage);
     }
 
     /**
@@ -113,7 +113,7 @@ public class ChatMessageService {
                 .orElseThrow(() -> new ChatMessageRetrievalException("서버 문제로 해당 메세지를 찾을 수 없습니다. 관리자에게 문의하세요."));
 
         // 채팅방 구독자들에게 메시지 전송
-        messagingTemplate.convertAndSend("/api/ws-stomp/reception/" + chatRoomId, responseChatMessage);
+        messagingTemplate.convertAndSend("/v1/ws-stomp/reception/" + chatRoomId, responseChatMessage);
     }
 
     /**

--- a/src/main/resources/application-common.yml
+++ b/src/main/resources/application-common.yml
@@ -33,21 +33,21 @@ spring:
             client-id: ${NAVER_CLIENT_ID}
             client-secret: ${NAVER_CLIENT_SECRET}
             client-name: naver
-            redirect-uri: https://boardbuddyapp.com/api/login/oauth2/code/naver
+            redirect-uri: https://boardbuddyapp.com/v1/login/oauth2/code/naver
             authorization-grant-type: authorization_code
             scope: name,email
           google:
             client-id: ${GOOGLE_CLIENT_ID}
             client-secret: ${GOOGLE_CLIENT_SECRET}
             client-name: google
-            redirect-uri: https://boardbuddyapp.com/api/login/oauth2/code/google
+            redirect-uri: https://boardbuddyapp.com/v1/login/oauth2/code/google
             authorization-grant-type: authorization_code
             scope: profile,email
           kakao:
             client-id: ${KAKAO_CLIENT_ID}
             client-secret: ${KAKAO_CLIENT_SECRET}
             client-name: kakao
-            redirect-uri: https://boardbuddyapp.com/api/login/oauth2/code/kakao
+            redirect-uri: https://boardbuddyapp.com/v1/login/oauth2/code/kakao
             authorization-grant-type: authorization_code
             client-authentication-method: client_secret_post
             scope: profile_nickname,account_email


### PR DESCRIPTION
## #️⃣연관된 이슈

> 이슈번호: #272 

## 📝작업 내용

> 백엔드 서버로의 모든 API 요청 및 프록시 경로 (/api/...) -> (/v1/...)로 수정

- AuthController.java
  - 인증 관련 API 요청 경로 (/api/...) -> (/v1/...)로 수정

- BadgeImageController.java
  - 뱃지 이미지 관련 API 요청 경로 (/api/...) -> (/v1/...)로 수정

- BoardCafeController.java
  - 보드게임 카페 정보 관련 API 요청 경로 (/api/...) -> (/v1/...)로 수정

- ChatMessageController.java
  - 채팅 관련 API 요청 경로 (/api/...) -> (/v1/...)로 수정

- ChatMessageService.java
  - 채팅 관련 API 요청 경로 (/api/...) -> (/v1/...)로 수정

- ChatRoomController.java
  - 채팅방 관련 API 요청 경로 (/api/...) -> (/v1/...)로 수정

- CommentController.java
  - 댓글 관련 API 요청 경로 (/api/...) -> (/v1/...)로 수정

- CustomAuthenticationFilter.java
  - 일반 로그인 관련 API 요청 경로 (/api/...) -> (/v1/...)로 수정

- GatherArticleController.java
  - 모집글 관련 API 요청 경로 (/api/...) -> (/v1/...)로 수정

- MemberController.java
  - 사용자 관련 API 요청 경로 (/api/...) -> (/v1/...)로 수정

- NotificationController.java
  - 알림 관련 API 요청 경로 (/api/...) -> (/v1/...)로 수정

- ParticipationApplicationController.java
  - 참가신청 관련 API 요청 경로 (/api/...) -> (/v1/...)로 수정

- PublicDistrictController.java
  - 공공 데이터 관련 API 요청 경로 (/api/...) -> (/v1/...)로 수정

- RankingController.java
  - 랭킹 관련 API 요청 경로 (/api/...) -> (/v1/...)로 수정

- ReviewController.java
  - 후기 작성 관련 API 요청 경로 (/api/...) -> (/v1/...)로 수정

- SecurityConfig.java
  - 사용자의 권한과 상관없이 모두 허용하는 API 요청 경로 (/api/...) -> (/v1/...)로 수정
  - 소셜 로그인 관련 API 요청 경로 (/api/...) -> (/v1/...)로 수정
  - 로그아웃 API 요청 경로 (/api/...) -> (/v1/...)로 수정

- WebMvcConfig.java
  - 사용자가 일반 로그인 사용자인지 소셜 로그인 사용자인지 구분하는 인터셉터 동작 관련 API 요청 경로 (/api/...) -> (/v1/...)로 수정

- WebsocketConfig.java
  - 메시지 발행 및 수신, 구독, 웹소켓 연결 관련 API 요청 경로 (/api/...) -> (/v1/...)로 수정

- nginx.conf
  - 백엔드 서버로의 모든 API 요청 프록시 경로 (/api/...) -> (/v1/...)로 수정

- application-common.yml.java
  - 소셜 로그인 관련 리다이렉트 경로 (/api/...) -> (/v1/...)로 수정