### PR TITLE
Feat: 이미 가입된 핸드폰 번호로 SMS 인증 시도시 예외 처리 로직 구현

### DIFF
--- a/src/main/java/sumcoda/boardbuddy/exception/member/PhoneNumberAlreadyExistsException.java
+++ b/src/main/java/sumcoda/boardbuddy/exception/member/PhoneNumberAlreadyExistsException.java
@@ -1,0 +1,7 @@
+package sumcoda.boardbuddy.exception.member;
+
+public class PhoneNumberAlreadyExistsException extends RuntimeException {
+    public PhoneNumberAlreadyExistsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/sumcoda/boardbuddy/handler/exception/MemberExceptionHandler.java
+++ b/src/main/java/sumcoda/boardbuddy/handler/exception/MemberExceptionHandler.java
@@ -22,6 +22,11 @@ public class MemberExceptionHandler {
         return buildFailureResponse(e.getMessage(), HttpStatus.CONFLICT);
     }
 
+    @ExceptionHandler(PhoneNumberAlreadyExistsException.class)
+    public ResponseEntity<ApiResponse<Void>> handlePhoneNumberAlreadyExistsException(PhoneNumberAlreadyExistsException e) {
+        return buildFailureResponse(e.getMessage(), HttpStatus.CONFLICT);
+    }
+
     @ExceptionHandler(MemberSaveException.class)
     public ResponseEntity<ApiResponse<Void>> handleMemberSaveException(MemberSaveException e) {
         return buildErrorResponse(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/main/java/sumcoda/boardbuddy/repository/member/MemberRepository.java
+++ b/src/main/java/sumcoda/boardbuddy/repository/member/MemberRepository.java
@@ -12,6 +12,8 @@ public interface MemberRepository extends JpaRepository<Member, Long>, MemberRep
 
     Boolean existsByNickname(String nickname);
 
+    Boolean existsByPhoneNumber(String phoneNumber);
+
     Optional<Member> findByUsername(String username);
 
     Optional<Member> findByNickname(String nickname);

--- a/src/main/java/sumcoda/boardbuddy/service/AuthService.java
+++ b/src/main/java/sumcoda/boardbuddy/service/AuthService.java
@@ -13,6 +13,7 @@ import sumcoda.boardbuddy.exception.auth.SMSCertificationAttemptExceededExceptio
 import sumcoda.boardbuddy.exception.auth.SMSCertificationExpiredException;
 import sumcoda.boardbuddy.exception.auth.SMSCertificationNumberMismatchException;
 import sumcoda.boardbuddy.exception.member.MemberRetrievalException;
+import sumcoda.boardbuddy.exception.member.PhoneNumberAlreadyExistsException;
 import sumcoda.boardbuddy.repository.member.MemberRepository;
 import sumcoda.boardbuddy.repository.SmsCertificationRepository;
 import sumcoda.boardbuddy.util.SmsCertificationUtil;
@@ -39,6 +40,11 @@ public class AuthService {
      **/
     public void sendSMS(AuthRequest.SendSMSCertificationDTO sendSMSCertificationDTO){
         String receivePhoneNumber = sendSMSCertificationDTO.getPhoneNumber();
+        Boolean isExistsPhoneNumber = memberRepository.existsByPhoneNumber(receivePhoneNumber);
+
+        if (isExistsPhoneNumber) {
+            throw new PhoneNumberAlreadyExistsException("이미 회원가입된 핸드폰 번호 입니다. 핸드폰 번호를 한번 더 확인하세요.");
+        }
 
         SecureRandom secureRandom = new SecureRandom();
         int randomNumber = 100000 + secureRandom.nextInt(900000);


### PR DESCRIPTION


## #️⃣연관된 이슈

> 이슈번호 : #276 

## 📝작업 내용

> 이미 가입된 핸드폰 번호로 SMS 인증 시도시 예외 처리 로직 구현

- MemberRepository.java
- existsByPhoneNumber() -> 핸드폰 번호가 이미 회원 가입된 핸드폰 번호인지 확인하는 메서드 추가

- PhoneNumberAlreadyExistsException.java
- 이미 회원가입된 핸드폰 번호인지 검증하는 예외 처리 클래스 구현

- MemberExceptionHandler.java
- handlePhoneNumberAlreadyExistsException() -> 핸드폰 번호가 이미 회원 가입된 핸드폰 번호인지 검증하는 예외 처리 핸들러 등록

- AuthService.java
- sendSMS() 메서드 내에 SMS 인증하려는 핸드폰 번호가 이미 회원 가입된 핸드폰 번호인지 검증하는 로직 추가