### PR TITLE
[Feat] 위치 관련 기능 임시 비활성화 재 추가 작업

### DIFF
--- a/src/main/java/sumcoda/boardbuddy/repository/member/MemberRepositoryCustomImpl.java
+++ b/src/main/java/sumcoda/boardbuddy/repository/member/MemberRepositoryCustomImpl.java
@@ -33,14 +33,37 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
                 .fetchOne());
     }
 
+    /**
+     * @apiNote 현재는 사용률 저조로 기존 메서드 비활성화된 상태
+     *          추후 사용자 요청 또는 트래픽 증가시 다시 활성화될 수 있음
+     */
+//    @Override
+//    public Optional<MemberResponse.ProfileDTO> findMemberDTOByUsername(String username) {
+//        return Optional.ofNullable(jpaQueryFactory
+//                .select(Projections.fields(MemberResponse.ProfileDTO.class,
+//                        member.nickname,
+//                        member.sido,
+//                        member.sgg,
+//                        member.emd,
+//                        member.phoneNumber,
+//                        member.memberType,
+//                        profileImage.profileImageS3SavedURL
+//                ))
+//                .from(member)
+//                .leftJoin(member.profileImage, profileImage)
+//                .where(member.username.eq(username))
+//                .fetchOne());
+//    }
+
+    /**
+     * @apiNote 임시로 활성화된 메서드
+     *          앱 사용률 증가시 비활성화후에 기존 기능 활성화 예정
+     */
     @Override
     public Optional<MemberResponse.ProfileDTO> findMemberDTOByUsername(String username) {
         return Optional.ofNullable(jpaQueryFactory
                 .select(Projections.fields(MemberResponse.ProfileDTO.class,
                         member.nickname,
-                        member.sido,
-                        member.sgg,
-                        member.emd,
                         member.phoneNumber,
                         member.memberType,
                         profileImage.profileImageS3SavedURL

--- a/src/main/java/sumcoda/boardbuddy/service/CustomOAuth2UserService.java
+++ b/src/main/java/sumcoda/boardbuddy/service/CustomOAuth2UserService.java
@@ -76,35 +76,69 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         SecureRandom secureRandom = new SecureRandom();
         int randomNumber = 10000000 + secureRandom.nextInt(90000000);
 
+        /**
+         * @apiNote 현재는 사용률 저조로 해당 로직 비활성화된 상태
+         *          추후 사용자 요청 또는 트래픽 증가시 다시 활성화될 수 있음
+         */
         // 만약 신규 로그인 회원이라면
-        if (findMember == null) {
-            Member member = Member.buildMember(
-                    username,
-                    bCryptPasswordEncoder.encode(oAuth2UserInfo.getEmail()),
-                    oAuth2UserInfo.getName() + randomNumber,
-                    oAuth2UserInfo.getEmail(),
-                    null,
-                    null,
-                    null,
-                    null,
-                    2,
-                    50.0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    null,
-                    null,
-                    0.0,
-                    MemberType.SOCIAL,
-                    Role.USER,
-                    null
-            );
+//        if (findMember == null) {
+//            Member member = Member.buildMember(
+//                    username,
+//                    bCryptPasswordEncoder.encode(oAuth2UserInfo.getEmail()),
+//                    oAuth2UserInfo.getName() + randomNumber,
+//                    oAuth2UserInfo.getEmail(),
+//                    null,
+//                    null,
+//                    null,
+//                    null,
+//                    2,
+//                    50.0,
+//                    0,
+//                    0,
+//                    0,
+//                    0,
+//                    0,
+//                    0,
+//                    0,
+//                    0,
+//                    0,
+//                    null,
+//                    null,
+//                    0.0,
+//                    MemberType.SOCIAL,
+//                    Role.USER,
+//                    null
+//            );
+
+            /**
+             * @apiNote 임시로 활성화된 멤버 생성 로직
+             *          앱 사용률 증가시 비활성화후에 기존 로직 활성화 예정
+             */
+            // 만약 신규 로그인 회원이라면
+            if (findMember == null) {
+                Member member = Member.buildMember(
+                        username,
+                        bCryptPasswordEncoder.encode(oAuth2UserInfo.getEmail()),
+                        oAuth2UserInfo.getName() + randomNumber,
+                        oAuth2UserInfo.getEmail(),
+                        null,
+                        50.0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        null,
+                        null,
+                        0.0,
+                        MemberType.SOCIAL,
+                        Role.USER,
+                        null
+                );
 
             memberRepository.save(member);
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> 이슈번호: #290 

## 📝작업 내용

- CustomOAuth2UserService.java
  - 위치 관련 기능 임시 비활성화 작업으로 인한 소셜 회원가입시 기존 멤버 생성 로직 비활성화 및 멤버 생성 임시 로직 추가

- MemberRepositoryCustomImpl.java
  - 위치 관련 기능 임시 비활성화로 인한 기존 findMemberDTOByUsername() 메서드 비활성화 및 임시 findMemberDTOByUsername() 메서드 추가