### PR TITLE
[Fix] 입장한 채팅방 목록 조회시 500(Internal Server Error) 응답 반환 이슈 해결

### DIFF
--- a/src/main/java/sumcoda/boardbuddy/dto/ChatMessageResponse.java
+++ b/src/main/java/sumcoda/boardbuddy/dto/ChatMessageResponse.java
@@ -146,6 +146,21 @@ public class ChatMessageResponse {
 
     @Getter
     @NoArgsConstructor
+    public static class LatestChatMessageInfoProjectionDTO {
+
+        private String content;
+
+        private Instant sentAt;
+
+        @Builder
+        public LatestChatMessageInfoProjectionDTO(String content, Instant sentAt) {
+            this.content = content;
+            this.sentAt = sentAt;
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
     public static class LatestChatMessageInfoDTO {
 
         private String content;

--- a/src/main/java/sumcoda/boardbuddy/dto/ChatRoomResponse.java
+++ b/src/main/java/sumcoda/boardbuddy/dto/ChatRoomResponse.java
@@ -20,19 +20,37 @@ public class ChatRoomResponse {
 
     @Getter
     @NoArgsConstructor
+    public static final class ChatRoomDetailsProjectionDTO {
+
+        private Long chatRoomId;
+
+        private GatherArticleResponse.SimpleInfoProjectionDTO gatherArticleSimpleProjectionInfo;
+
+        private ChatMessageResponse.LatestChatMessageInfoProjectionDTO latestChatMessageInfoProjectionDTO;
+
+        @Builder
+        public ChatRoomDetailsProjectionDTO(Long chatRoomId, GatherArticleResponse.SimpleInfoProjectionDTO gatherArticleSimpleProjectionInfo, ChatMessageResponse.LatestChatMessageInfoProjectionDTO latestChatMessageInfoProjectionDTO) {
+            this.chatRoomId = chatRoomId;
+            this.gatherArticleSimpleProjectionInfo = gatherArticleSimpleProjectionInfo;
+            this.latestChatMessageInfoProjectionDTO = latestChatMessageInfoProjectionDTO;
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
     public static final class ChatRoomDetailsDTO {
 
         private Long chatRoomId;
 
         private GatherArticleResponse.SimpleInfoDTO gatherArticleSimpleInfo;
 
-        private ChatMessageResponse.LatestChatMessageInfoDTO latestChatMessageInfo;
+        private ChatMessageResponse.LatestChatMessageInfoDTO latestChatMessageInfoDTO;
 
         @Builder
-        public ChatRoomDetailsDTO(Long chatRoomId, GatherArticleResponse.SimpleInfoDTO gatherArticleSimpleInfo, ChatMessageResponse.LatestChatMessageInfoDTO latestChatMessageInfo) {
+        public ChatRoomDetailsDTO(Long chatRoomId, GatherArticleResponse.SimpleInfoDTO gatherArticleSimpleInfo, ChatMessageResponse.LatestChatMessageInfoDTO latestChatMessageInfoDTO) {
             this.chatRoomId = chatRoomId;
             this.gatherArticleSimpleInfo = gatherArticleSimpleInfo;
-            this.latestChatMessageInfo = latestChatMessageInfo;
+            this.latestChatMessageInfoDTO = latestChatMessageInfoDTO;
         }
     }
 

--- a/src/main/java/sumcoda/boardbuddy/dto/GatherArticleResponse.java
+++ b/src/main/java/sumcoda/boardbuddy/dto/GatherArticleResponse.java
@@ -260,6 +260,27 @@ public class GatherArticleResponse {
 
     @Getter
     @NoArgsConstructor
+    public static class SimpleInfoProjectionDTO {
+
+        private Long gatherArticleId;
+
+        private String title;
+
+        private String meetingLocation;
+
+        private Integer currentParticipants;
+
+        @Builder
+        public SimpleInfoProjectionDTO(Long gatherArticleId, String title, String meetingLocation, Integer currentParticipants) {
+            this.gatherArticleId = gatherArticleId;
+            this.title = title;
+            this.meetingLocation = meetingLocation;
+            this.currentParticipants = currentParticipants;
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
     public static class SimpleInfoDTO {
 
         private Long gatherArticleId;

--- a/src/main/java/sumcoda/boardbuddy/repository/chatRoom/ChatRoomRepositoryCustom.java
+++ b/src/main/java/sumcoda/boardbuddy/repository/chatRoom/ChatRoomRepositoryCustom.java
@@ -11,5 +11,5 @@ public interface ChatRoomRepositoryCustom {
 
     Optional<ChatRoomResponse.ValidateDTO> findValidateDTOByGatherArticleId(Long gatherArticleId);
 
-    List<ChatRoomResponse.ChatRoomDetailsDTO> findChatRoomDetailsListByUsername(String username);
+    List<ChatRoomResponse.ChatRoomDetailsProjectionDTO> findChatRoomDetailsListByUsername(String username);
 }

--- a/src/main/java/sumcoda/boardbuddy/repository/chatRoom/ChatRoomRepositoryCustomImpl.java
+++ b/src/main/java/sumcoda/boardbuddy/repository/chatRoom/ChatRoomRepositoryCustomImpl.java
@@ -48,22 +48,22 @@ public class ChatRoomRepositoryCustomImpl implements ChatRoomRepositoryCustom {
      * @return 사용자가 속한 채팅방의 상세 정보 목록
      **/
     @Override
-    public List<ChatRoomResponse.ChatRoomDetailsDTO> findChatRoomDetailsListByUsername(String username) {
+    public List<ChatRoomResponse.ChatRoomDetailsProjectionDTO> findChatRoomDetailsListByUsername(String username) {
         QChatMessage subQueryChatMessage = new QChatMessage("subQueryChatMessage");
         QChatRoom subQueryChatRoom = new QChatRoom("subQueryChatRoom");
         return jpaQueryFactory
-                .select(Projections.fields(ChatRoomResponse.ChatRoomDetailsDTO.class,
+                .select(Projections.fields(ChatRoomResponse.ChatRoomDetailsProjectionDTO.class,
                         chatRoom.id.as("chatRoomId"),
-                        Projections.fields(GatherArticleResponse.SimpleInfoDTO.class,
+                        Projections.fields(GatherArticleResponse.SimpleInfoProjectionDTO.class,
                                 gatherArticle.id.as("gatherArticleId"),
                                 gatherArticle.title,
                                 gatherArticle.meetingLocation,
                                 gatherArticle.currentParticipants
-                        ).as("gatherArticleSimpleInfo"),
-                        Projections.fields(ChatMessageResponse.LatestChatMessageInfoDTO.class,
+                        ).as("gatherArticleSimpleProjectionInfo"),
+                        Projections.fields(ChatMessageResponse.LatestChatMessageInfoProjectionDTO.class,
                                 chatMessage.content,
                                 chatMessage.createdAt.as("sentAt")
-                        ).as("latestChatMessageInfo")
+                        ).as("latestChatMessageInfoProjectionDTO")
                 ))
                 .from(memberChatRoom)
                 .join(memberChatRoom.member, member)

--- a/src/main/java/sumcoda/boardbuddy/service/ChatRoomService.java
+++ b/src/main/java/sumcoda/boardbuddy/service/ChatRoomService.java
@@ -4,7 +4,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import sumcoda.boardbuddy.dto.ChatMessageResponse;
 import sumcoda.boardbuddy.dto.ChatRoomResponse;
+import sumcoda.boardbuddy.dto.GatherArticleResponse;
 import sumcoda.boardbuddy.dto.MemberChatRoomResponse;
 import sumcoda.boardbuddy.entity.ChatRoom;
 import sumcoda.boardbuddy.entity.GatherArticle;
@@ -22,6 +24,8 @@ import sumcoda.boardbuddy.repository.member.MemberRepository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+
+import static sumcoda.boardbuddy.util.ChatRoomUtil.convertToChatRoomDetailsDTO;
 
 @Service
 @RequiredArgsConstructor
@@ -131,7 +135,8 @@ public class ChatRoomService {
         if (!isMemberExists) {
             throw new MemberRetrievalException("서버 문제로 사용자의 정보를 찾을 수 없습니다. 관리자에게 문의하세요.");
         }
+        List<ChatRoomResponse.ChatRoomDetailsProjectionDTO> chatRoomDetailsListByUsername = chatRoomRepository.findChatRoomDetailsListByUsername(username);
 
-        return chatRoomRepository.findChatRoomDetailsListByUsername(username);
+        return convertToChatRoomDetailsDTO(chatRoomDetailsListByUsername);
     }
 }

--- a/src/main/java/sumcoda/boardbuddy/util/ChatRoomUtil.java
+++ b/src/main/java/sumcoda/boardbuddy/util/ChatRoomUtil.java
@@ -1,0 +1,40 @@
+package sumcoda.boardbuddy.util;
+
+import sumcoda.boardbuddy.dto.ChatMessageResponse;
+import sumcoda.boardbuddy.dto.ChatRoomResponse;
+import sumcoda.boardbuddy.dto.GatherArticleResponse;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+
+public class ChatRoomUtil {
+
+    public static List<ChatRoomResponse.ChatRoomDetailsDTO> convertToChatRoomDetailsDTO(List<ChatRoomResponse.ChatRoomDetailsProjectionDTO> chatRoomDetailsListByUsername) {
+        return chatRoomDetailsListByUsername.stream().map(chatRoomDetailsProjectionDTO -> {
+
+                    GatherArticleResponse.SimpleInfoProjectionDTO gatherArticleSimpleProjectionInfo = chatRoomDetailsProjectionDTO.getGatherArticleSimpleProjectionInfo();
+
+                    GatherArticleResponse.SimpleInfoDTO gatherArticleSimpleInfoDTO = GatherArticleResponse.SimpleInfoDTO.builder()
+                            .gatherArticleId(gatherArticleSimpleProjectionInfo.getGatherArticleId())
+                            .title(gatherArticleSimpleProjectionInfo.getTitle())
+                            .meetingLocation(gatherArticleSimpleProjectionInfo.getMeetingLocation())
+                            .currentParticipants(gatherArticleSimpleProjectionInfo.getCurrentParticipants())
+                            .build();
+
+                    ChatMessageResponse.LatestChatMessageInfoProjectionDTO latestChatMessageInfoProjectionDTO = chatRoomDetailsProjectionDTO.getLatestChatMessageInfoProjectionDTO();
+
+                    ChatMessageResponse.LatestChatMessageInfoDTO latestChatMessageInfoDTO = ChatMessageResponse.LatestChatMessageInfoDTO.builder()
+                            .content(latestChatMessageInfoProjectionDTO.getContent())
+                            .sentAt(LocalDateTime.ofInstant(latestChatMessageInfoProjectionDTO.getSentAt(), ZoneId.systemDefault()))
+                            .build();
+
+                    return ChatRoomResponse.ChatRoomDetailsDTO.builder()
+                            .chatRoomId(chatRoomDetailsProjectionDTO.getChatRoomId())
+                            .gatherArticleSimpleInfo(gatherArticleSimpleInfoDTO)
+                            .latestChatMessageInfoDTO(latestChatMessageInfoDTO)
+                            .build();
+                })
+                .toList();
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> 이슈번호: #296

## 📝작업 내용

> 입장한 채팅방 목록 조회시 발생하는 IllegalArgumentException 해결

- ChatMessageResponse.java
  - 기존 DTO 클래스를 DB 조회 역할과 클라이언트에게 값을 반환하는 역할로 구분하기 위한 클래스 구현
  - DB 에서 값을 조회하는 역할의 LatestChatMessageInfoProjectionDTO 클래스 구현

- ChatRoomRepositoryCustom.java
  - findChatRoomDetailsListByUsername() 메서드의 리턴 타입 ChatRoomDetailsDTO -> ChatRoomDetailsProjectionDTO로 변경

- ChatRoomRepositoryCustomImpl.java
  - findChatRoomDetailsListByUsername() 메서드의 리턴 타입 및 Projection 클래스 타입 변경

- ChatRoomResponse.java
  - 기존 DTO 클래스를 DB 조회 역할과 클라이언트에게 값을 반환하는 역할로 구분하기 위한 클래스 구현
  - DB 에서 값을 조회하는 역할의 ChatRoomDetailsProjectionDTO 클래스 구현

- ChatRoomService.java
  - DB 에서 조회한 값을 클라이언트에게 반환하기 위한 값으로 변환하는 로직 추가

- ChatRoomUtil.java
  - DB 에서 조회한 값을 클라이언트에게 반환하기 위한 값으로 변환하는 convertToChatRoomDetailsDTO() 메서드 구현

- GatherArticleResponse.java
  - 기존 DTO 클래스를 DB 조회 역할과 클라이언트에게 값을 반환하는 역할로 구분하기 위한 클래스 구현
  - DB 에서 값을 조회하는 역할의 SimpleInfoProjectionDTO 클래스 구현