### PR TITLE
[Refactor/#298] 시/도 목록 반환 API - 응답 필드 추가

### DIFF
--- a/src/main/java/sumcoda/boardbuddy/dto/RegionResponse.java
+++ b/src/main/java/sumcoda/boardbuddy/dto/RegionResponse.java
@@ -3,7 +3,7 @@ package sumcoda.boardbuddy.dto;
 
 public class RegionResponse {
 
-    public record ProvinceDTO(String code, String name) {}
+    public record ProvinceDTO(String code, String name, String officialName) {}
 
     public record DistrictDTO(String name) {}
 }

--- a/src/main/java/sumcoda/boardbuddy/enumerate/Province.java
+++ b/src/main/java/sumcoda/boardbuddy/enumerate/Province.java
@@ -9,7 +9,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public enum Province {
 
-    SEOUL("서울", List.of(
+    SEOUL("서울", "서울특별시", List.of(
             District.SEOUL_ALL,
             District.SEOUL_GANGNAM,
             District.SEOUL_GANGDONG,
@@ -38,7 +38,7 @@ public enum Province {
             District.SEOUL_JUNGRANG
     )),
 
-    GYEONGGI("경기", List.of(
+    GYEONGGI("경기", "경기도", List.of(
             District.GYEONGGI_ALL,
             District.GYEONGGI_GAPYEONG,
             District.GYEONGGI_GOYANG_DEOKYANG,
@@ -84,7 +84,7 @@ public enum Province {
             District.GYEONGGI_HWASEONG
     )),
 
-    GANGWON("강원", List.of(
+    GANGWON("강원", "강원특별자치도", List.of(
             District.GANGWON_ALL,
             District.GANGWON_GANGNEUNG,
             District.GANGWON_GOSEONG,
@@ -106,7 +106,7 @@ public enum Province {
             District.GANGWON_HOENGSEONG
     )),
 
-    BUSAN("부산", List.of(
+    BUSAN("부산", "부산광역시", List.of(
             District.BUSAN_ALL,
             District.BUSAN_GANGSEO,
             District.BUSAN_GEUMJEONG,
@@ -126,7 +126,7 @@ public enum Province {
             District.BUSAN_HAEUNDAE
     )),
 
-    DAEGU("대구", List.of(
+    DAEGU("대구", "대구광역시", List.of(
             District.DAEGU_ALL,
             District.DAEGU_NAMGU,
             District.DAEGU_DALSEO,
@@ -138,7 +138,7 @@ public enum Province {
             District.DAEGU_JUNG
     )),
 
-    INCHEON("인천", List.of(
+    INCHEON("인천", "인천광역시", List.of(
             District.INCHEON_ALL,
             District.INCHEON_GANGHWA,
             District.INCHEON_GYEYANG,
@@ -152,7 +152,7 @@ public enum Province {
             District.INCHEON_JUNG
     )),
 
-    GWANGJU("광주", List.of(
+    GWANGJU("광주", "광주광역시", List.of(
             District.GWANGJU_ALL,
             District.GWANGJU_GWANGSAN,
             District.GWANGJU_NAMGU,
@@ -161,7 +161,7 @@ public enum Province {
             District.GWANGJU_SEOGU
     )),
 
-    DAEJEON("대전", List.of(
+    DAEJEON("대전", "대전광역시", List.of(
             District.DAEJEON_ALL,
             District.DAEJEON_DADEOK,
             District.DAEJEON_DONGGU,
@@ -170,7 +170,7 @@ public enum Province {
             District.DAEJEON_JUNG
     )),
 
-    ULSAN("울산", List.of(
+    ULSAN("울산", "울산광역시", List.of(
             District.ULSAN_ALL,
             District.ULSAN_NAMGU,
             District.ULSAN_DONGGU,
@@ -179,11 +179,11 @@ public enum Province {
             District.ULSAN_JUNG
     )),
 
-    SEJONG("세종", List.of(
+    SEJONG("세종", "세종특별자치시", List.of(
             District.SEJONG_ALL
     )),
 
-    CHUNGBUK("충북", List.of(
+    CHUNGBUK("충북", "충청북도", List.of(
             District.CHUNGBUK_ALL,
             District.CHUNGBUK_GOESAN,
             District.CHUNGBUK_DANYANG,
@@ -201,7 +201,7 @@ public enum Province {
             District.CHUNGBUK_CHUNGJU
     )),
 
-    CHUNGNAM("충남", List.of(
+    CHUNGNAM("충남", "충청남도", List.of(
             District.CHUNGNAM_ALL,
             District.CHUNGNAM_GYERYONG,
             District.CHUNGNAM_GONGJU,
@@ -221,7 +221,7 @@ public enum Province {
             District.CHUNGNAM_HONGSEONG
     )),
 
-    JEONBUK("전북", List.of(
+    JEONBUK("전북", "전라북도", List.of(
             District.JEONBUK_ALL,
             District.JEONBUK_GOCHANG,
             District.JEONBUK_GUNSAN,
@@ -240,7 +240,7 @@ public enum Province {
             District.JEONBUK_JINAN
     )),
 
-    JEONNAM("전남", List.of(
+    JEONNAM("전남", "전라남도", List.of(
             District.JEONNAM_ALL,
             District.JEONNAM_GANGJIN,
             District.JEONNAM_GOHEUNG,
@@ -266,7 +266,7 @@ public enum Province {
             District.JEONNAM_HWASUN
     )),
 
-    GYEONGBUK("경북", List.of(
+    GYEONGBUK("경북", "경상북도", List.of(
             District.GYEONGBUK_ALL,
             District.GYEONGBUK_GYEONGSAN,
             District.GYEONGBUK_GYEONGJU,
@@ -294,7 +294,7 @@ public enum Province {
             District.GYEONGBUK_POHANG_BUKGU
     )),
 
-    GYEONGNAM("경남", List.of(
+    GYEONGNAM("경남", "경상남도", List.of(
             District.GYEONGNAM_ALL,
             District.GYEONGNAM_GEOJE,
             District.GYEONGNAM_GEACHANG,
@@ -320,13 +320,13 @@ public enum Province {
             District.GYEONGNAM_HAPCHEON
     )),
 
-    JEJU("제주", List.of(
+    JEJU("제주", "제주특별자치도", List.of(
             District.JEJU_ALL,
             District.JEJU_SEOGWIPO,
             District.JEJU_JEJU
     ));
 
-    private final String name;
-
+    private final String name; // 축양형 명칭 (서울, 경기 등)
+    private final String officialName; // 공식 행정구역 명칭 (서울특별시, 경기도 등)
     private final List<District> districts;
 }

--- a/src/main/java/sumcoda/boardbuddy/service/RegionService.java
+++ b/src/main/java/sumcoda/boardbuddy/service/RegionService.java
@@ -15,11 +15,11 @@ public class RegionService {
     /**
      * 전체 시/도 목록을 조회
      *
-     * @return List<ProvinceDto> 시도 코드(code)와 한글명(name) 리스트
+     * @return List<ProvinceDto> 시도 코드(code)와 축약형 명칭(name), 공식 행정구역 명칭(officialName) 리스트
      */
     public List<RegionResponse.ProvinceDTO> getProvinceList() {
         return Stream.of(Province.values())
-                .map(p -> new RegionResponse.ProvinceDTO(p.name(), p.getName()))
+                .map(p -> new RegionResponse.ProvinceDTO(p.name(), p.getName(), p.getOfficialName()))
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> This closes #298 

## 📝작업 내용

> 기존 데이터의 시/도 명칭이 공식 행정구역 명칭과 달라, 필터링에 문제가 발생함. 공식 행정구역 명칭 (officialName) 을 함께 보내도록 DTO 및 서비스, 지역 데이터 수정

- Province.java
    - Province enum에 공식 행정구역 명칭을 의미하는 officialName 필드 추가

- RegionResponse.java
    - ProvinceDTO 레코드에 officialName 필드 추가

- RegionService.java
    - officialName 필드를 추가하여 반환하도록 getProvinceList() 메서드 수정

## 💬리뷰 요구사항

> 디스코드 2차 - 이슈 - '모집글 조회 지역 필터링 관련 이슈' 에 따른 수정사항 입니다. 