### PR TITLE
[Refactor] 특정 API 요청 인증 비활성화 작업

### DIFF
--- a/src/main/java/sumcoda/boardbuddy/config/SecurityConfig.java
+++ b/src/main/java/sumcoda/boardbuddy/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package sumcoda.boardbuddy.config;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -111,7 +112,16 @@ public class SecurityConfig {
                                 "/api/auth/login",
                                 "/api/oauth2/**",
                                 "/api/login/oauth2/code/**",
-                                "/api/auth/locations/search"
+                                "/api/board-cafes",
+                                "/api/regions/**",
+                                "/api/rankings"
+                        ).permitAll()
+                        .requestMatchers(
+                                // 동일한 URL 요청에 대해서 GET 요청만 permitAll()
+                                HttpMethod.GET,
+                                "/api/gather-articles",
+                                "/api/gather-articles/{gatherArticleId}",
+                                "/api/gather-articles/{gatherArticleId}/comments"
                         ).permitAll()
                         // 단순히 로그인한 인증 여부만 확인
 //                        .anyRequest().authenticated()
@@ -150,7 +160,7 @@ public class SecurityConfig {
                         .failureHandler(oAuth2AuthenticationFailureHandler));
 
         http.logout(auth -> auth
-                .logoutUrl("/api/v1/auth/logout")
+                .logoutUrl("/api/auth/logout")
                 .logoutSuccessHandler(customLogoutSuccessHandler)
                 .deleteCookies("JSESSIONID"));
 

--- a/src/main/java/sumcoda/boardbuddy/config/WebMvcConfig.java
+++ b/src/main/java/sumcoda/boardbuddy/config/WebMvcConfig.java
@@ -2,12 +2,15 @@ package sumcoda.boardbuddy.config;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import sumcoda.boardbuddy.interceptor.AuthenticationInterceptor;
+import sumcoda.boardbuddy.interceptor.HttpMethodFilteringInterceptor;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 @Configuration
 @RequiredArgsConstructor
@@ -15,23 +18,51 @@ public class WebMvcConfig implements WebMvcConfigurer {
 
     private final AuthenticationInterceptor authenticationInterceptor;
 
+    // 2) gather-articles 관련 엔드포인트
+    private static final List<String> GATHER_ARTICLE_PATHS = List.of(
+            "/api/gather-articles",
+            "/api/gather-articles/*",
+            "/api/gather-articles/*/comments"
+    );
+
+    // 3) 전체 /api/** 중에서 exclude할 경로들
+    private static final List<String> GLOBAL_EXCLUDES =
+            Stream.concat(
+                    GATHER_ARTICLE_PATHS.stream(),
+                    List.of( "/api/auth/register",
+                                    "/api/auth/username/check",
+                                    "/api/auth/nickname/check",
+                                    "/api/auth/sms-certifications/send",
+                                    "/api/auth/sms-certifications/verify",
+                                    "/api/auth/login",
+                                    "/api/oauth2/**",
+                                    "/api/login/oauth2/code/**",
+                                    "/api/board-cafes",
+                                    "/api/regions/**",
+                                    "/api/rankings")
+                            .stream()
+            ).toList();
+
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
+        // 1) gather-articles 전용: POST/PUT/DELETE만 인터셉트
+        registry.addInterceptor(
+                        new HttpMethodFilteringInterceptor(
+                                authenticationInterceptor,
+                                HttpMethod.POST.name(),
+                                HttpMethod.PUT.name(),
+                                HttpMethod.DELETE.name()
+                        )
+                )
+                .addPathPatterns(GATHER_ARTICLE_PATHS.toArray(String[]::new));
+
+        // 2) 공통 API: /api/** 전체 인터셉트
+        //    -> gather-articles 관련과 regions, rankings... 는 제외
         registry.addInterceptor(authenticationInterceptor)
                 .addPathPatterns("/api/**")
-                .excludePathPatterns(List.of(
-                        "/api/auth/register",
-                        "/api/auth/username/check",
-                        "/api/auth/nickname/check",
-                        "/api/auth/sms-certifications/send",
-                        "/api/auth/sms-certifications/verify",
-                        "/api/auth/login",
-                        "/api/oauth2/**",
-                        "/api/login/oauth2/code/**",
-                        "/api/auth/locations/search",
-                        "/api/rankings"
-                ));
-        WebMvcConfigurer.super.addInterceptors(registry);
+                .excludePathPatterns(GLOBAL_EXCLUDES.toArray(String[]::new));
+
+
     }
 
     // 로컬 테스트용 저장공간 설정

--- a/src/main/java/sumcoda/boardbuddy/controller/BoardCafeController.java
+++ b/src/main/java/sumcoda/boardbuddy/controller/BoardCafeController.java
@@ -30,18 +30,16 @@ public class BoardCafeController {
      * @param x 경도
      * @param y 위도
      * @param radius 반경 (단위: 미터)
-     * @param username 사용자 이름
      * @return 보드게임 카페 리스트
      */
     @GetMapping("/api/board-cafes")
     public ResponseEntity<ApiResponse<Map<String, List<BoardCafeResponse.InfoDTO>>>> getBoardCafes(
             @RequestParam Double x,
             @RequestParam Double y,
-            @RequestParam Integer radius,
-            @RequestAttribute String username) {
+            @RequestParam Integer radius) {
         log.info("getBoardCafes is working");
 
-        List<BoardCafeResponse.InfoDTO> cafes = boardCafeService.getBoardCafes(x, y, radius, username);
+        List<BoardCafeResponse.InfoDTO> cafes = boardCafeService.getBoardCafes(x, y, radius);
 
         return buildSuccessResponseWithPairKeyData("cafes", cafes, "보드 게임 카페 조회를 성공하였습니다.", HttpStatus.OK);
     }

--- a/src/main/java/sumcoda/boardbuddy/controller/CommentController.java
+++ b/src/main/java/sumcoda/boardbuddy/controller/CommentController.java
@@ -54,16 +54,14 @@ public class CommentController {
      * 댓글 조회 요청
      *
      * @param gatherArticleId 모집글 ID
-     * @param username        사용자 이름
      * @return 댓글 리스트 응답
      */
     @GetMapping("/api/gather-articles/{gatherArticleId}/comments")
     public ResponseEntity<ApiResponse<Map<String, List<CommentResponse.InfoDTO>>>> getComments(
-            @PathVariable Long gatherArticleId,
-            @RequestAttribute String username) {
+            @PathVariable Long gatherArticleId) {
         log.info("getComments is working");
 
-        List<CommentResponse.InfoDTO> comments = commentService.getComments(gatherArticleId, username);
+        List<CommentResponse.InfoDTO> comments = commentService.getComments(gatherArticleId);
 
         return buildSuccessResponseWithPairKeyData("comments", comments, "댓글 조회를 성공하였습니다.", HttpStatus.OK);
     }

--- a/src/main/java/sumcoda/boardbuddy/interceptor/HttpMethodFilteringInterceptor.java
+++ b/src/main/java/sumcoda/boardbuddy/interceptor/HttpMethodFilteringInterceptor.java
@@ -1,0 +1,30 @@
+package sumcoda.boardbuddy.interceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.util.Set;
+
+public class HttpMethodFilteringInterceptor implements HandlerInterceptor {
+
+    private final HandlerInterceptor delegateInterceptor;
+
+    private final Set<String> methodsToIntercept;
+
+    public HttpMethodFilteringInterceptor(HandlerInterceptor delegateInterceptor, String... methodsToIntercept) {
+        this.delegateInterceptor = delegateInterceptor;
+        this.methodsToIntercept = Set.of(methodsToIntercept);
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        // 1) 감시할 메서드가 아니면 바로 통과
+        if (!methodsToIntercept.contains(request.getMethod())) {
+            return true;
+        }
+        // 2) 감시할 메서드일 때만 실제 인터셉터(인증) 로직 위임
+        return delegateInterceptor.preHandle(request, response, handler);
+    }
+
+}

--- a/src/main/java/sumcoda/boardbuddy/service/BoardCafeService.java
+++ b/src/main/java/sumcoda/boardbuddy/service/BoardCafeService.java
@@ -29,15 +29,9 @@ public class BoardCafeService {
      * @param x 경도
      * @param y 위도
      * @param radius 반경 (단위: 미터)
-     * @param username 사용자 이름
      * @return 보드게임 카페 리스트
      */
-    public List<BoardCafeResponse.InfoDTO> getBoardCafes(Double x, Double y, Integer radius , String username) {
-
-        // 유저 검증
-        if (username == null) {
-            throw new MemberRetrievalException("보드 게임 카페 찾기 요청을 처리할 수 없습니다. 관리자에게 문의하세요.");
-        }
+    public List<BoardCafeResponse.InfoDTO> getBoardCafes(Double x, Double y, Integer radius) {
 
         // 반경 검증
         if (radius < MIN_RADIUS || radius > MAX_RADIUS) {

--- a/src/main/java/sumcoda/boardbuddy/service/CommentService.java
+++ b/src/main/java/sumcoda/boardbuddy/service/CommentService.java
@@ -84,15 +84,9 @@ public class CommentService {
      * 댓글 조회
      *
      * @param gatherArticleId 모집글 ID
-     * @param username        사용자 이름
      * @return 댓글 리스트
      */
-    public List<CommentResponse.InfoDTO> getComments(Long gatherArticleId, String username) {
-
-        // 멤버 검증
-        if (!memberRepository.existsByUsername(username)) {
-            throw new MemberRetrievalException("서버 문제로 사용자의 정보를 찾을 수 없습니다. 관리자에게 문의하세요.");
-        }
+    public List<CommentResponse.InfoDTO> getComments(Long gatherArticleId) {
 
         // 모집글 검증
         GatherArticleResponse.IdDTO idDTO = gatherArticleRepository.findIdDTOById(gatherArticleId)


### PR DESCRIPTION
## #️⃣연관된 이슈

> 이슈번호: #304 

## 📝작업 내용

> 로그인하지 않은 사용자라도 경험할 수 있는 서비스 요소들을 늘리기 위한 인증 안화 작업

- BoardCafeController.java
  - getBoardCafes() 메서드 내에 필요하지 않은 매개변수 username 삭제

- BoardCafeService.java
  - getBoardCafes() 메서드 내에 필요하지 않은 매개변수 username 삭제 및 username 관련 로직 삭제

- CommentController.java
  - getComments() 메서드 내에 필요하지 않은 매개변수 username 삭제

- CommentService.java
  - getComments() 메서드 내에 필요하지 않은 매개변수 username 삭제 및 username 관련 로직 삭제

- HttpMethodFilteringInterceptor.java
  - '/api/gather-articles', '/api/gather-articles/{gatherArticleId}', '/api/gather-articles/{gatherArticleId}/comments' 요청 중에 GET 요청을 제외한 POST, PUT, DELETE 요청만 인터셉트하여 요청을 보낸 사용자의 username을 저장하기 위한 인터셉터 구현

- SecurityConfig.java
  - 인증 완화를 적용할 요청 URL 추가

- WebMvcConfig.java
  - 요청을 보낸 사용자의 username을 저장하기 위한 인터셉터 동작을 제외할 요청 URL 추가
  - '/api/gather-articles', '/api/gather-articles/{gatherArticleId}', '/api/gather-articles/{gatherArticleId}/comments' 요청 중에 GET 요청을 제외한 POST, PUT, DELETE 요청만 인터셉트하여 요청을 보낸 사용자의 username을 저장하기 위한 HttpMethodFilteringInterceptor 등록 로직 구현