### PR TITLE
[Refactor] 모집글 상세 조회 API 분리 작업

### DIFF
--- a/src/main/java/sumcoda/boardbuddy/controller/GatherArticleController.java
+++ b/src/main/java/sumcoda/boardbuddy/controller/GatherArticleController.java
@@ -75,16 +75,32 @@ public class GatherArticleController {
     /**
      * 모집글 조회 요청
      *
-     * @param gatherArticleId   조회 요청 모집글 id
-     * @param username          사용자 username
-     * @return                  조회된 모집글과 관련된 응답 데이터
+     * @param gatherArticleId 조회 요청 모집글 ID
+     * @return 조회된 모집글과 관련된 응답 데이터
      */
     @GetMapping(value = "/api/gather-articles/{gatherArticleId}")
-    public ResponseEntity<ApiResponse<Map<String, GatherArticleResponse.ReadDTO>>> getGatherArticle(
-            @PathVariable Long gatherArticleId,
-            @RequestAttribute String username) {
-        GatherArticleResponse.ReadDTO readResponse = gatherArticleService.getGatherArticle(gatherArticleId, username);
-        return buildSuccessResponseWithPairKeyData("post", readResponse, "성공적으로 조회되었습니다.", HttpStatus.OK);
+    public ResponseEntity<ApiResponse<Map<String, GatherArticleResponse.DetailedInfoDTO>>> getGatherArticle(
+            @PathVariable Long gatherArticleId) {
+
+        GatherArticleResponse.DetailedInfoDTO gatherArticleDetailedInfo = gatherArticleService.getGatherArticle(gatherArticleId);
+
+        return buildSuccessResponseWithPairKeyData("post", gatherArticleDetailedInfo, "모집글 상세 정보를 성공적으로 조회 하였습니다.", HttpStatus.OK);
+    }
+
+    /**
+     * 모집글 참가 신청 현황 조회
+     *
+     * @param gatherArticleId 조회 요청 모집글 ID
+     * @param username 사용자 username
+     * @return 모집글에 대한 요청을 보낸 사용자의 참가 신청 현황
+     */
+    @GetMapping(value = "/api/gather-articles/{gatherArticleId}/participation-status")
+    public ResponseEntity<ApiResponse<Map<String, GatherArticleResponse.ParticipationApplicationStatusDTO>>> getParticipationApplicationStatus(
+            @PathVariable Long gatherArticleId, @RequestAttribute String username) {
+
+        GatherArticleResponse.ParticipationApplicationStatusDTO readResponse = gatherArticleService.getParticipationApplicationStatus(gatherArticleId, username);
+
+        return buildSuccessResponseWithPairKeyData("post", readResponse, "모집글 참가 신청 현황을 성공적으로 조회 하였습니다.", HttpStatus.OK);
     }
 
     /**

--- a/src/main/java/sumcoda/boardbuddy/dto/GatherArticleResponse.java
+++ b/src/main/java/sumcoda/boardbuddy/dto/GatherArticleResponse.java
@@ -68,7 +68,7 @@ public class GatherArticleResponse {
 
     @Getter
     @NoArgsConstructor
-    public static class ReadDTO {
+    public static class DetailedInfoDTO {
         private String title;
         private String description;
         private GatherArticleResponse.AuthorDTO author;
@@ -87,12 +87,11 @@ public class GatherArticleResponse {
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
         private LocalDateTime createdAt;
         private GatherArticleStatus status;
-        private ParticipationApplicationStatus participationApplicationStatus;
 
         @Builder
-        public ReadDTO(String title, String description, AuthorDTO author, String sido, String sgg, String emd, String meetingLocation, Double x, Double y,
-                       Integer maxParticipants, Integer currentParticipants, LocalDateTime startDateTime,
-                       LocalDateTime endDateTime, LocalDateTime createdAt, GatherArticleStatus status, ParticipationApplicationStatus participationApplicationStatus) {
+        public DetailedInfoDTO(String title, String description, AuthorDTO author, String sido, String sgg, String emd, String meetingLocation, Double x, Double y,
+                               Integer maxParticipants, Integer currentParticipants, LocalDateTime startDateTime,
+                               LocalDateTime endDateTime, LocalDateTime createdAt, GatherArticleStatus status) {
             this.title = title;
             this.description = description;
             this.author = author;
@@ -108,9 +107,19 @@ public class GatherArticleResponse {
             this.endDateTime = endDateTime;
             this.createdAt = createdAt;
             this.status = status;
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class ParticipationApplicationStatusDTO {
+
+        private ParticipationApplicationStatus participationApplicationStatus;
+
+        @Builder
+        public ParticipationApplicationStatusDTO(ParticipationApplicationStatus participationApplicationStatus) {
             this.participationApplicationStatus = participationApplicationStatus;
         }
-
     }
 
     @Getter

--- a/src/main/java/sumcoda/boardbuddy/repository/gatherArticle/GatherArticleRepositoryCustom.java
+++ b/src/main/java/sumcoda/boardbuddy/repository/gatherArticle/GatherArticleRepositoryCustom.java
@@ -37,7 +37,9 @@ public interface GatherArticleRepositoryCustom {
 
     Optional<GatherArticleResponse.SummaryInfoDTO> findSimpleInfoByGatherArticleId(Long gatherArticleId);
 
-    GatherArticleResponse.ReadDTO findGatherArticleReadDTOByGatherArticleId(Long gatherArticleId, Long memberId);
+    GatherArticleResponse.DetailedInfoDTO findGatherArticleDetailedInfoDTOByGatherArticleId(Long gatherArticleId);
+
+    GatherArticleResponse.ParticipationApplicationStatusDTO findParticipationApplicationStatusDTOByGatherArticleIdAndUsername(Long gatherArticleId, String username);
 
     Optional<GatherArticleResponse.TitleDTO> findTitleDTOById(Long gatherArticleId);
 

--- a/src/main/java/sumcoda/boardbuddy/service/GatherArticleService.java
+++ b/src/main/java/sumcoda/boardbuddy/service/GatherArticleService.java
@@ -115,21 +115,42 @@ public class GatherArticleService {
     }
 
     /**
-     * 모집글 조회
-     * @param gatherArticleId, username
-     * @return
+     * 모집글 상세 조회
+     * @param gatherArticleId 모집글 ID
+     * @return 모집글 상세 정보
      */
-    public GatherArticleResponse.ReadDTO getGatherArticle(Long gatherArticleId, String username) {
+    public GatherArticleResponse.DetailedInfoDTO getGatherArticle(Long gatherArticleId) {
 
         // 존재하는 모집글인지 확인
-        GatherArticleResponse.IdDTO gatherArticleIdDTO = gatherArticleRepository.findIdDTOById(gatherArticleId)
-                .orElseThrow(() -> new GatherArticleNotFoundException("존재하지 않는 모집글입니다."));
+        boolean isGatherArticleExists = gatherArticleRepository.existsById(gatherArticleId);
+        if (!isGatherArticleExists) {
+            throw new GatherArticleNotFoundException("존재하지 않는 모집글입니다.");
+        }
+
+        return gatherArticleRepository.findGatherArticleDetailedInfoDTOByGatherArticleId(gatherArticleId);
+    }
+
+    /**
+     * 모집글 참가 신청 현황 조회
+     * @param gatherArticleId 모집글 ID
+     * @param username 사용자 username
+     * @return 모집글에 대한 요청을 보낸 사용자의 참가 신청 현황
+     */
+    public GatherArticleResponse.ParticipationApplicationStatusDTO getParticipationApplicationStatus(Long gatherArticleId, String username) {
+
+        // 존재하는 모집글인지 확인
+        boolean isGatherArticleExists = gatherArticleRepository.existsById(gatherArticleId);
+        if (!isGatherArticleExists) {
+            throw new GatherArticleNotFoundException("존재하지 않는 모집글입니다.");
+        }
 
         // 사용자 검증
-        MemberResponse.IdDTO memberIdDTO = memberRepository.findIdDTOByUsername(username)
-                .orElseThrow(() -> new MemberRetrievalException("유효하지 않은 사용자입니다."));
+        Boolean IsUserExists = memberRepository.existsByUsername(username);
+        if (!IsUserExists){
+            throw new MemberRetrievalException("유효하지 않은 사용자입니다.");
+        }
 
-        return gatherArticleRepository.findGatherArticleReadDTOByGatherArticleId(gatherArticleIdDTO.getId(), memberIdDTO.getId());
+        return gatherArticleRepository.findParticipationApplicationStatusDTOByGatherArticleIdAndUsername(gatherArticleId, username);
     }
 
     /**


### PR DESCRIPTION
## #️⃣연관된 이슈

> 이슈번호: #306

## 📝작업 내용

> 기존 '모집글 상세 조회' API를 '모집글 상세 조회' API, '모집글 참가 신청 상태 조회' API로 분리하여 구현

- GatherArticleController.java
  - 모집글 상세 정보 조회 요청을 처리하는 기존의 getGatherArticle() 로직 수정
  - 모집글 참가 신청 상태 조회 요청 처리를 위한 getParticipationApplicationStatus() 구현

- GatherArticleRepositoryCustom.java
  - 모집글 상세 정보 조회를 위한 기존의 findGatherArticleReadDTOByGatherArticleId() 리턴 타입, 메서드 이름 및 매개 변수 수정
  - 모집글 참가 신청 상태를 DB에서 조회하기 위한 findParticipationApplicationStatusDTOByGatherArticleIdAndUsername() 선언

- GatherArticleRepositoryCustomImpl.java
  - 모집글 상세 정보 조회를 위한 기존의 findGatherArticleReadDTOByGatherArticleId() 리턴 타입, 메서드 이름 및 매개 변수 수정 및 쿼리 수정
  - 모집글 참가 신청 상태를 DB에서 조회하기 위한 findParticipationApplicationStatusDTOByGatherArticleIdAndUsername() 내에 쿼리 작성 및 구현

- GatherArticleResponse.java
  - 모집글 상세 정보 조회를 위한 기존의 ReadDTO -> DetailedInfoDTO 클래스 이름 수정 및 불필요한 필드 제거
  - 모집글 참가 신청 상태를 DB에서 조회하여 매핑하기 위한 ParticipationApplicationStatusDTO 클래스 구현

- GatherArticleService.java
  - 모집글 상세 정보 조회를 위한 기존 getGatherArticle() 리턴 타입, 매개 변수 및 로직 수정
  - 모집글 참가 신청 상태 조회를 위한 getParticipationApplicationStatus() 구현