### PR TITLE
[Fix] 모집글 참가 신청 현황 조회시 500 (INTERNAL SERVER ERROR) 응답 이슈 해결 작업

### DIFF
--- a/src/main/java/sumcoda/boardbuddy/repository/gatherArticle/GatherArticleRepositoryCustomImpl.java
+++ b/src/main/java/sumcoda/boardbuddy/repository/gatherArticle/GatherArticleRepositoryCustomImpl.java
@@ -365,7 +365,8 @@ public class GatherArticleRepositoryCustomImpl implements GatherArticleRepositor
             QParticipationApplication participationApplication) {
         return new CaseBuilder()
                 .when(participationApplication.id.isNull()).then(ParticipationApplicationStatus.NONE)
-                .otherwise(participationApplication.participationApplicationStatus);
+                .otherwise(participationApplication.participationApplicationStatus)
+                .as("participationApplicationStatus");
     }
 
     @Override


### PR DESCRIPTION
## #️⃣연관된 이슈

> 이슈번호: #309

## 📝작업 내용

> 모집글 참가 신청 현황 조회시 500 (INTERNAL SERVER ERROR) 응답 이슈 해결 작업

- GatherArticleRepositoryCustomImpl.java
  - DB에서 모집글 참가 신청 현황 조회시 활용하는 participationApplicationStatusExpression() 쿼리 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?