### PR TITLE
Refactor: AWS Secret Manger 활성화

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,8 +60,9 @@ jobs:
           SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KAKAO_CLIENT_SECRET=${{ secrets.KAKAO_CLIENT_SECRET }}
           SPRING_CLOUD_AWS_CLOUD_FRONT_DOMAIN=${{ secrets.PROD_CLOUD_FRONT_DOMAIN}}
           SPRING_CLOUD_AWS_CLOUD_FRONT_KEY_PAIR_ID=${{ secrets.PROD_CLOUD_FRONT_KEY_PAIR_ID}}
-          SPRING_CLOUD_AWS_CLOUD_FRONT_PRIVATE_KEY=${{ secrets.PROD_CLOUD_FRONT_PRIVATE_KEY}}
           SPRING_CLOUD_AWS_CLOUD_FRONT_URL_EXPIRATION_MINUTES=${{ secrets.PROD_CLOUD_FRONT_URL_EXPIRATION_MINUTES}}
+          SPRING_CLOUD_AWS_CLOUD_FRONT_SECRET_REGION=${{ secrets.PROD_CLOUD_FRONT_SECRET_REGION}}
+          SPRING_CLOUD_AWS_CLOUD_FRONT_SECRET_NAME=${{ secrets.PROD_CLOUD_FRONT_SECRET_NAME}}
           SPRING_PROFILES_ACTIVE=common,prod
           EOF
 
@@ -114,8 +115,8 @@ jobs:
           sudo docker run -d --name redis \
             -v /home/ec2-user/redis.conf:/usr/local/etc/redis/redis.conf \
             --network spring-boot-app-network \
-            -e REDIS_PASSWORD=${PROD_REDIS_PASSWORD} \
-            -p 6379:6379 redis:latest redis-server /usr/local/etc/redis/redis.conf
+            -e REDIS_PASSWORD=${{ secrets.PROD_REDIS_PASSWORD }} \
+            -p 6379:${{ secrets.PROD_REDIS_PORT }} redis:latest redis-server /usr/local/etc/redis/redis.conf
 
           # Spring Boot 애플리케이션 컨테이너 재시작
           if sudo docker ps -a -q -f name=spring-boot-app; then

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,13 @@ repositories {
     mavenCentral()
 }
 
+dependencyManagement {
+    imports {
+        // 최신 안정화 BOM 버전
+        mavenBom "software.amazon.awssdk:bom:2.32.10"
+    }
+}
+
 dependencies {
 //    implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -35,10 +42,13 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-quartz'
 
     // AWS S3 의존성 추가
-    implementation "software.amazon.awssdk:s3:2.31.78"
+    implementation 'software.amazon.awssdk:s3'
+
+    // AWS Secret Manager 의존성 추가
+    implementation 'software.amazon.awssdk:secretsmanager'
 
     // Cloud Font 의존성 추가
-    implementation 'software.amazon.awssdk:cloudfront:2.31.77'
+    implementation 'software.amazon.awssdk:cloudfront'
 
     // CoolSMS 의존성 추가
     implementation 'net.nurigo:sdk:4.3.0'

--- a/src/main/java/sumcoda/boardbuddy/config/CloudFrontConfig.java
+++ b/src/main/java/sumcoda/boardbuddy/config/CloudFrontConfig.java
@@ -4,26 +4,33 @@ import lombok.Getter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.cloudfront.CloudFrontUtilities;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
 
 import java.security.KeyFactory;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.Base64;
 
+@Getter
 @Configuration
 @ConfigurationProperties(prefix = "spring.cloud.aws.cloud-front")
-@Getter
 public class CloudFrontConfig {
 
     private String domain;
 
     private String keyPairId;
 
-    // PEM 문자열 직접 주입
-    private String privateKeyPem;
-
     private int urlExpirationMinutes;
+
+    private String secretRegion;
+
+    //Secrets Manager 시크릿 이름 프로퍼티
+    private String secretName;
+
+
 
     @Bean
     public CloudFrontUtilities cloudFrontUtilities() {
@@ -31,18 +38,31 @@ public class CloudFrontConfig {
     }
 
     @Bean
-    public RSAPrivateKey cloudFrontRSAPrivateKey() throws Exception {
-        // PEM 헤더/스페이스 제거 후 Base64 디코드
+    public SecretsManagerClient secretsManagerClient() {
+        return SecretsManagerClient.builder()
+                .region(Region.of(this.secretRegion)).build();
+    }
+
+    @Bean
+    public RSAPrivateKey cloudFrontRSAPrivateKey(SecretsManagerClient secretsManagerClient) throws Exception {
+        // 1) Secrets Manager에서 PEM 문자열 읽기
+        GetSecretValueRequest getSecretValueRequest = GetSecretValueRequest.builder()
+                .secretId(this.secretName)
+                .build();
+
+        String privateKeyPem = secretsManagerClient.getSecretValue(getSecretValueRequest).secretString();
+
+        // 2) PEM 헤더/스페이스 제거 후 Base64 디코드
         String base64 = privateKeyPem
                 .replace("-----BEGIN (.*)-----", "")
                 .replace("-----END (.*)-----", "")
                 .replaceAll("\\s+", "");
 
-        byte[] der = Base64.getDecoder().decode(base64);
+        byte[] decode = Base64.getDecoder().decode(base64);
 
-        PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(der);
+        PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(decode);
 
-        return (RSAPrivateKey) KeyFactory.getInstance("RSA").generatePrivate(spec);
+        return (RSAPrivateKey) KeyFactory.getInstance("RSA")
+                .generatePrivate(keySpec);
     }
-
 }

--- a/src/main/java/sumcoda/boardbuddy/service/CloudFrontSignedUrlService.java
+++ b/src/main/java/sumcoda/boardbuddy/service/CloudFrontSignedUrlService.java
@@ -36,13 +36,13 @@ public class CloudFrontSignedUrlService {
         Instant expiration = CloudFrontSignedUrlUtil.calculateExpiration(cloudFrontConfig.getUrlExpirationMinutes());
 
         // 3. Canned policy 방식으로 Signed URL 생성
-        CannedSignerRequest signerReq = CannedSignerRequest.builder()
+        CannedSignerRequest cannedSignerRequest = CannedSignerRequest.builder()
                 .resourceUrl(resourceUrl)
                 .privateKey(cloudFrontRSAPrivateKey)
                 .keyPairId(cloudFrontConfig.getKeyPairId())
                 .expirationDate(expiration)
                 .build();
 
-        return cloudFrontUtilities.getSignedUrlWithCannedPolicy(signerReq).url();
+        return cloudFrontUtilities.getSignedUrlWithCannedPolicy(cannedSignerRequest).url();
     }
 }

--- a/src/main/java/sumcoda/boardbuddy/util/CloudFrontSignedUrlUtil.java
+++ b/src/main/java/sumcoda/boardbuddy/util/CloudFrontSignedUrlUtil.java
@@ -1,6 +1,5 @@
 package sumcoda.boardbuddy.util;
 
-import java.sql.Date;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 
@@ -31,8 +30,6 @@ public final class CloudFrontSignedUrlUtil {
      * @return 만료 시각을 나타내는 Instant 객체
      */
     public static Instant calculateExpiration(int minutes) {
-        Instant expiration = Instant.now().plus(minutes, ChronoUnit.MINUTES);
-
-        return Date.from(expiration).toInstant();
+        return Instant.now().plus(minutes, ChronoUnit.MINUTES);
     }
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -33,15 +33,13 @@ spring:
           region: ${PROD_S3_BUCKET_REGION}
         stack:
           auto: false
-
       cloud-front:
         domain: ${PROD_CLOUD_FRONT_DOMAIN}
         key-pair-id: ${PROD_CLOUD_FRONT_KEY_PAIR_ID}
-        private-key: ${PROD_CLOUD_FRONT_PRIVATE_KEY}
+        secret:
+          region: ${PROD_CLOUD_FRONT_SECRET_REGION}
+          name: ${PROD_CLOUD_FRONT_SECRET_NAME}
         url-expiration-minutes: ${PROD_CLOUD_FRONT_URL_EXPIRATION_MINUTES}
-
-
-
 
   cool-sms:
     api-key: ${PROD_SMS_API_KEY}


### PR DESCRIPTION
## #️⃣연관된 이슈

> 이슈번호: #318

## 📝작업 내용

>  Private Key를 서버에서 활용하기 위한 AWS Secret Manager 서비스 활성화 작업 및 기존 로직 수정

- application-prod.yml
  - 환경 변수 수정

- build.gradle
  - AWS Secret Manager 서비스 활성화를 위한 의존성 추가

- CloudFrontConfig.java
  - AWS Secret Manager 서비스 활성화를 위한 프로퍼티 추가
  - secretsManagerClient 빈 메서드 추가
  - cloudFrontRSAPrivateKey() 빈 메서드 로직 수정

- CloudFrontSignedUrlService.java
  - generateSignedUrl() 메서드 내에 필드 이름 수정

- CloudFrontSignedUrlUtil.java
  - calculateExpiration() 메서드 로직 최적화

- deploy.yml
  - 배포환경 서버에서 활용할 환경 변수 수정
  - 배포 파이프라인 동작시 필요한 올바른 환경변수 매핑
### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?