### PR TITLE
[Refactor] 로그인시 인증 실패 예외 처리 흐름 개선

### DIFF
--- a/src/main/java/sumcoda/boardbuddy/dto/auth/CustomAuthenticationProvider.java
+++ b/src/main/java/sumcoda/boardbuddy/dto/auth/CustomAuthenticationProvider.java
@@ -5,11 +5,11 @@ import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 import sumcoda.boardbuddy.exception.auth.AuthenticationMissingException;
 import sumcoda.boardbuddy.exception.auth.InvalidPasswordException;
-import sumcoda.boardbuddy.exception.member.MemberRetrievalException;
 
 @Component
 @RequiredArgsConstructor
@@ -30,7 +30,7 @@ public class CustomAuthenticationProvider implements AuthenticationProvider {
 
         CustomUserDetails userDetails = (CustomUserDetails) userDetailsService.loadUserByUsername(username);
         if (userDetails == null) {
-            throw new MemberRetrievalException("해당 유저를 찾을 수 없습니다. 관리자에게 문의하세요.");
+            throw new UsernameNotFoundException("해당 유저를 찾을 수 없습니다. 관리자에게 문의하세요.");
         }
 
         if(!passwordEncoder.matches(password, userDetails.getPassword())) {

--- a/src/main/java/sumcoda/boardbuddy/exception/auth/InvalidPasswordException.java
+++ b/src/main/java/sumcoda/boardbuddy/exception/auth/InvalidPasswordException.java
@@ -1,6 +1,8 @@
 package sumcoda.boardbuddy.exception.auth;
 
-public class InvalidPasswordException extends RuntimeException {
+import org.springframework.security.core.AuthenticationException;
+
+public class InvalidPasswordException extends AuthenticationException {
     public InvalidPasswordException(String message) {
         super(message);
     }

--- a/src/main/java/sumcoda/boardbuddy/exception/member/MemberRetrievalException.java
+++ b/src/main/java/sumcoda/boardbuddy/exception/member/MemberRetrievalException.java
@@ -1,8 +1,6 @@
 package sumcoda.boardbuddy.exception.member;
 
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
-
-public class MemberRetrievalException extends UsernameNotFoundException {
+public class MemberRetrievalException extends RuntimeException {
     public MemberRetrievalException(String message) {
         super(message);
     }

--- a/src/main/java/sumcoda/boardbuddy/handler/auth/CustomAuthenticationFailureHandler.java
+++ b/src/main/java/sumcoda/boardbuddy/handler/auth/CustomAuthenticationFailureHandler.java
@@ -1,18 +1,19 @@
 package sumcoda.boardbuddy.handler.auth;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.InternalAuthenticationServiceException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
+import sumcoda.boardbuddy.exception.auth.InvalidPasswordException;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -27,40 +28,51 @@ public class CustomAuthenticationFailureHandler implements AuthenticationFailure
         log.info("authentication failure handler is working");
         Map<String, Object> responseData = new HashMap<>();
 
-        String errorMessage = "";
-
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8");
 
+        String errorMessage = getErrorMessage(response, exception);
 
-        if (exception instanceof UsernameNotFoundException || exception instanceof BadCredentialsException) {
-            response.setStatus(HttpStatus.BAD_REQUEST.value());
-            errorMessage = "입력한 회원 정보가 올바르지 않습니다. 올바른 회원정보를 입력하세요.";
-            responseData.put("status", "failure");
-        }
-        else if (exception instanceof InternalAuthenticationServiceException) {
+        responseData.put("status", "failure");
+        responseData.put("data", null);
+        responseData.put("message", errorMessage);
+
+        objectMapper.writeValue(response.getWriter(), responseData);
+    }
+
+    private static String getErrorMessage(HttpServletResponse response, AuthenticationException exception) {
+        String errorMessage;
+
+        if (exception instanceof BadCredentialsException ||
+                exception instanceof UsernameNotFoundException ||
+                exception instanceof InvalidPasswordException) {
+            response.setStatus(HttpStatus.UNAUTHORIZED.value());
+            if (exception instanceof BadCredentialsException) {
+                errorMessage = "입력한 회원 정보가 올바르지 않습니다. 올바른 회원정보를 입력하세요.";
+            } else {
+                errorMessage = exception.getMessage();
+            }
+        } else if (exception instanceof InternalAuthenticationServiceException) {
             response.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
+
             errorMessage = "내부 시스템 문제로 로그인 요청을 처리할 수 없습니다. 관리자에게 문의하세요.";
-            responseData.put("status", "error");
+        } else if (exception instanceof AuthenticationCredentialsNotFoundException) {
+            response.setStatus(HttpStatus.FORBIDDEN.value());
 
+            errorMessage = "인증 요청이 거부되었습니다. 관리자에게 문의하세요.";
+        } else {
+            response.setStatus(HttpStatus.UNAUTHORIZED.value());
+
+            errorMessage = "인증에 실패했습니다.";
         }
-
-//        else if(exception instanceof DisabledException) {
+        //        else if(exception instanceof DisabledException) {
 //            errorMessage = "Locked";
 //        }
 //        else if(exception instanceof CredentialsExpiredException) {
 //            errorMessage = "Expired password";
 //        }
 
-//        else if (exception instanceof AuthenticationCredentialsNotFoundException) {
-//            errorMessage = "인증 요청이 거부되었습니다. 관리자에게 문의하세요.";
-//        }
-
-        responseData.put("data", null);
-        responseData.put("message", errorMessage);
-
-        objectMapper.writeValue(response.getWriter(), responseData);
-
+        return errorMessage;
     }
 }
 

--- a/src/main/java/sumcoda/boardbuddy/handler/auth/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/sumcoda/boardbuddy/handler/auth/CustomAuthenticationSuccessHandler.java
@@ -31,14 +31,13 @@ public class CustomAuthenticationSuccessHandler implements AuthenticationSuccess
 
     private final MemberProfileMapper memberProfileMapper;
 
-    final ObjectMapper objectMapper = new ObjectMapper();
-
-    Map<String, Object> responseData = new HashMap<>();
-
-
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
         log.info("success handler is working");
+
+        final ObjectMapper objectMapper = new ObjectMapper();
+
+        Map<String, Object> responseData = new HashMap<>();
 
         if (authentication == null) {
             throw new AuthenticationMissingException("인증 객체가 누락되었습니다. 관리자에게 문의하세요.");


### PR DESCRIPTION
## #️⃣연관된 이슈

> 이슈번호: #322

## 📝작업 내용

> 로그인 시 아이디/비밀번호 오류 모두 로그인 실패 핸들러 내에서 의도한 응답이 반환되도록 로직 정리 및 예외 메시지 처리 로직 개선, 예외 클래스의 상속 클래스 수정

- CustomAuthenticationFailureHandler.java
  - 로그인 시 아이디/비밀번호 오류 모두 CustomAuthenticationFailureHandler 내에서 의도한 응답을 반환하도록 onAuthenticationFailure() 내부에서 예외 처리 로직 개선
  - 던져지는 예외에 따라 동적으로 에러 메세지를 클라이언트로 응답하기 위한 getErrorMessage() 메서드 구현

- CustomAuthenticationProvider.java
  - authenticate() 메서드 내에 로그인시 올바르지 않은 아이디를 입력하는 경우 던져지는 예외를 MemberRetrievalException -> UsernameNotFoundException로 수정

- CustomAuthenticationSuccessHandler.java
  - objectMapper, responseData, 필드를 AuthenticationSuccess() 메서드 실행시에만 초기화 되도록 AuthenticationSuccess() 내부로 위치 변경

- InvalidPasswordException.java
  - RuntimeException -> AuthenticationException을 상속하도록 수정

- MemberRetrievalException.java
  - UsernameNotFoundException -> RuntimeException을 상속하도록 수정