### PR TITLE
[Refactor] 로그인시 인증 실패 예외 처리 흐름 개선 추가 작업

### DIFF
--- a/src/main/java/sumcoda/boardbuddy/dto/auth/CustomAuthenticationProvider.java
+++ b/src/main/java/sumcoda/boardbuddy/dto/auth/CustomAuthenticationProvider.java
@@ -10,6 +10,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 import sumcoda.boardbuddy.exception.auth.AuthenticationMissingException;
 import sumcoda.boardbuddy.exception.auth.InvalidPasswordException;
+import sumcoda.boardbuddy.exception.auth.InvalidUsernameException;
 
 @Component
 @RequiredArgsConstructor
@@ -30,11 +31,11 @@ public class CustomAuthenticationProvider implements AuthenticationProvider {
 
         CustomUserDetails userDetails = (CustomUserDetails) userDetailsService.loadUserByUsername(username);
         if (userDetails == null) {
-            throw new UsernameNotFoundException("해당 유저를 찾을 수 없습니다. 관리자에게 문의하세요.");
+            throw new InvalidUsernameException("유효하지 않은 아이디 입니다. 올바른 아이디를 입력하였는지 확인해주세요.");
         }
 
         if(!passwordEncoder.matches(password, userDetails.getPassword())) {
-            throw new InvalidPasswordException("유효하지 않은 비밀번호 입니다. 올바른 비밀번호를 입력하였는지 확인해주세요");
+            throw new InvalidPasswordException("유효하지 않은 비밀번호 입니다. 올바른 비밀번호를 입력하였는지 확인해주세요.");
         }
 
         return new CustomAuthenticationToken(userDetails, null, userDetails.getAuthorities());

--- a/src/main/java/sumcoda/boardbuddy/exception/auth/InvalidUsernameException.java
+++ b/src/main/java/sumcoda/boardbuddy/exception/auth/InvalidUsernameException.java
@@ -1,0 +1,9 @@
+package sumcoda.boardbuddy.exception.auth;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class InvalidUsernameException extends AuthenticationException {
+    public InvalidUsernameException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/sumcoda/boardbuddy/handler/auth/CustomAuthenticationFailureHandler.java
+++ b/src/main/java/sumcoda/boardbuddy/handler/auth/CustomAuthenticationFailureHandler.java
@@ -10,10 +10,10 @@ import org.springframework.security.authentication.AuthenticationCredentialsNotF
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.InternalAuthenticationServiceException;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
 import sumcoda.boardbuddy.exception.auth.InvalidPasswordException;
+import sumcoda.boardbuddy.exception.auth.InvalidUsernameException;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -44,7 +44,7 @@ public class CustomAuthenticationFailureHandler implements AuthenticationFailure
         String errorMessage;
 
         if (exception instanceof BadCredentialsException ||
-                exception instanceof UsernameNotFoundException ||
+                exception instanceof InvalidUsernameException ||
                 exception instanceof InvalidPasswordException) {
             response.setStatus(HttpStatus.UNAUTHORIZED.value());
             if (exception instanceof BadCredentialsException) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> 이슈번호: #324

## 📝작업 내용

> 로그인 아이디 오류시 던져지는 예외 수정을 위한 커스텀 예외 클래스 구현 및 로그인 실패 핸들러 내에서 의도한 응답이 반환되도록 예외 메시지 처리 메서드 수정

- CustomAuthenticationFailureHandler.java
  - 로그인시 유효하지 않은 아이디를 입력했을 경우 클라이언트로 의도된 에러 메시지를 응답하도록 getErrorMessage() 메서드 수정

- CustomAuthenticationProvider.java
  - authenticate() 메서드 내에 로그인시 올바르지 않은 아이디를 입력하는 경우 던져지는 예외를 UsernameNotFoundException -> InvalidUsernameException 수정

- InvalidUsernameException.java
  - 로그인시 유효하지 않은 아이디를 입력했을 경우에 던져지는 예외 클래스 구현