### PR TITLE
[Refactor] 비로그인시에도 유저 상태 확인 API 요청 허용을 위한 작업

### DIFF
--- a/src/main/java/sumcoda/boardbuddy/config/SecurityConfig.java
+++ b/src/main/java/sumcoda/boardbuddy/config/SecurityConfig.java
@@ -114,7 +114,8 @@ public class SecurityConfig {
                                 "/api/login/oauth2/code/**",
                                 "/api/board-cafes",
                                 "/api/regions/**",
-                                "/api/rankings"
+                                "/api/rankings",
+                                "/api/auth/status"
                         ).permitAll()
                         .requestMatchers(
                                 // 동일한 URL 요청에 대해서 GET 요청만 permitAll()

--- a/src/main/java/sumcoda/boardbuddy/config/WebMvcConfig.java
+++ b/src/main/java/sumcoda/boardbuddy/config/WebMvcConfig.java
@@ -29,7 +29,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
     private static final List<String> GLOBAL_EXCLUDES =
             Stream.concat(
                     GATHER_ARTICLE_PATHS.stream(),
-                    List.of( "/api/auth/register",
+                    Stream.of( "/api/auth/register",
                                     "/api/auth/username/check",
                                     "/api/auth/nickname/check",
                                     "/api/auth/sms-certifications/send",
@@ -39,8 +39,8 @@ public class WebMvcConfig implements WebMvcConfigurer {
                                     "/api/login/oauth2/code/**",
                                     "/api/board-cafes",
                                     "/api/regions/**",
-                                    "/api/rankings")
-                            .stream()
+                                    "/api/rankings"
+                            )
             ).toList();
 
     @Override

--- a/src/main/java/sumcoda/boardbuddy/interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/sumcoda/boardbuddy/interceptor/AuthenticationInterceptor.java
@@ -8,6 +8,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
+import sumcoda.boardbuddy.exception.auth.AuthenticationMissingException;
 import sumcoda.boardbuddy.util.AuthUtil;
 
 @Component
@@ -19,6 +20,10 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(HttpServletRequest request, @NotNull HttpServletResponse response, @NotNull Object handler) throws Exception {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null) {
+            throw new AuthenticationMissingException("로그인 하지 않은 사용자의 요청입니다.");
+        }
 
         String username = authUtil.getUserNameByLoginType(authentication);
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> 이슈번호: #327 

## 📝작업 내용

> 로그인 유저 뿐만 아니라 비로그인 유저도 유저 상태 확인 API 요청을 허용하는 리팩토링 작업

- AuthenticationInterceptor.java
  - 인증되지 않은 사용자의 요청시 약속된 응답을 클라이언트로 반환하기 위한 preHandle() 메서드 로직 수정

- SecurityConfig.java
  - filterChain() 내에 인증되지 않은 사용자도 유저 상태 확인 API 요청을 허용하기 위한 permitAll() URL 추가

- WebMvcConfig.java
  - GLOBAL_EXCLUDES 필드 값을 구성하는 기존 로직 최적화