### PR TITLE
[Refactor] 비로그인시에도 유저 상태 확인 API 요청 허용을 위한 추가 작업

### DIFF
--- a/src/main/java/sumcoda/boardbuddy/interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/sumcoda/boardbuddy/interceptor/AuthenticationInterceptor.java
@@ -21,7 +21,7 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
     public boolean preHandle(HttpServletRequest request, @NotNull HttpServletResponse response, @NotNull Object handler) throws Exception {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
-        if (authentication == null) {
+        if (authentication == null || !authentication.isAuthenticated()) {
             throw new AuthenticationMissingException("로그인 하지 않은 사용자의 요청입니다.");
         }
 

--- a/src/main/java/sumcoda/boardbuddy/util/AuthUtil.java
+++ b/src/main/java/sumcoda/boardbuddy/util/AuthUtil.java
@@ -20,10 +20,6 @@ public class AuthUtil {
      */
     public String getUserNameByLoginType(Authentication authentication) {
 
-        if (!authentication.isAuthenticated()) {
-            throw new AuthenticationMissingException("유효하지 않은 사용자의 요청입니다.(인터셉터 동작)");
-        }
-
         String username;
 
         if (authentication instanceof OAuth2AuthenticationToken) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> 이슈번호: #329

## 📝작업 내용

>  로그인 유저 뿐만 아니라 비로그인 유저도 유저 상태 확인 API 요청을 허용하는 추가 리팩토링 작업

- AuthenticationInterceptor.java
  - 인증되지 않은 사용자의 요청시 약속된 응답을 클라이언트로 반환하기 위한 preHandle() 메서드 로직 추가 수정

- AuthUtil.java
  - getUserNameByLoginType() 메서드 내에 불필요한 로직 삭제