### PR TITLE
[Fix] 프로필 이미지 수정시 발생하는 이슈 해결 작업

### DIFF
--- a/src/main/java/sumcoda/boardbuddy/entity/Member.java
+++ b/src/main/java/sumcoda/boardbuddy/entity/Member.java
@@ -315,15 +315,28 @@ public class Member {
 //                .build();
 //    }
 
+    // 양방향 연관 관계 공개 편의 메서드
+    public void assignProfileImage(ProfileImage newProfileImage) {
+        assignProfileImage(newProfileImage, true);
+    }
+
     // Member 1 <-> 1 ProfileImage
-    // 양방향 연관관계 편의 메서드
-    public void assignProfileImage(ProfileImage profileImage) {
-        if (this.profileImage != null) {
-            this.profileImage.assignMember(null);
+    // 양방향 연관 관계 비공개 편의 메서드
+    void assignProfileImage(ProfileImage newProfileImage, boolean updateInverseSide) {
+        if (this.profileImage == newProfileImage) return;
+
+        ProfileImage old = this.profileImage;
+        this.profileImage = newProfileImage;
+
+        if (!updateInverseSide) return;
+
+        // 1) 끊기
+        if (old != null && old.getMember() == this) {
+            old.assignMember(null, /*sync=*/false);
         }
-        this.profileImage = profileImage;
-        if (profileImage != null && profileImage.getMember() != this) {
-            profileImage.assignMember(this);
+        // 2) 연결
+        if (newProfileImage != null && newProfileImage.getMember() != this) {
+            newProfileImage.assignMember(this, /*sync=*/false);
         }
     }
 

--- a/src/main/java/sumcoda/boardbuddy/entity/ProfileImage.java
+++ b/src/main/java/sumcoda/boardbuddy/entity/ProfileImage.java
@@ -43,14 +43,22 @@ public class ProfileImage {
     }
 
     // ProfileImage 1 <-> 1 Member
-    // 양방향 연관관계 편의 메서드
-    public void assignMember(Member member) {
-        if (this.member != null) {
-            this.member.assignProfileImage(null);
+    // 양방향 연관 관계 비공개 편의 메서드
+    void assignMember(Member newMember, boolean updateInverseSide) {
+        if (this.member == newMember) return;
+
+        Member old = this.member;
+        this.member = newMember;
+
+        if (!updateInverseSide) return;
+
+        // 끊기
+        if (old != null && old.getProfileImage() == this) {
+            old.assignProfileImage(null, false);
         }
-        this.member = member;
-        if (member != null && member.getProfileImage() != this) {
-            member.assignProfileImage(this);
+        // 연결
+        if (newMember != null && newMember.getProfileImage() != this) {
+            newMember.assignProfileImage(this, false);
         }
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> 이슈번호: #333

## 📝작업 내용

> 프로필 이미지 수정시 양방향 연관 관계 편의 메서드 호출로 인하여 발생하는 StackOverFlowError 해결 작업

- Member.java
  - 양방향 연관 관계 공개 편의 메서드 assignProfileImage() 구현
  - 기존 양방향 연관 관계 편의 메서드를 호출시 발생하는 StackOverFlowError를 해결하기 위해 플래그 변수를 활용하여 무한 호출이 발생하지 않도록 기존 assignProfileImage() 메서드를 양방향 연관관계 비공개 편의 메서드로 리팩토링

- ProfileImage.java
  - 별도의 양방향 연관 관계 공개 편의 메서드 assignMember()는 필요하지 않으므로 구현하지 않음
  - 기존 양방향 연관 관계 편의 메서드를 호출시 발생하는 StackOverFlowError를 해결하기 위해 플래그 변수를 활용하여 무한 호출이 발생하지 않도록 기존 assignMember() 메서드를 양뱡향 연관 관계 비공개 편의 메서드로 리팩토링