### PR TITLE
[Refactor] 로그인 확인 API 반환 데이터 수정 작업

### DIFF
--- a/src/main/java/sumcoda/boardbuddy/controller/AuthController.java
+++ b/src/main/java/sumcoda/boardbuddy/controller/AuthController.java
@@ -10,11 +10,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
 import sumcoda.boardbuddy.dto.AuthRequest;
-import sumcoda.boardbuddy.dto.client.MemberSummaryDTO;
 import sumcoda.boardbuddy.dto.common.ApiResponse;
 import sumcoda.boardbuddy.service.AuthService;
-
-import java.util.Map;
 
 import static sumcoda.boardbuddy.builder.ResponseBuilder.*;
 
@@ -62,12 +59,10 @@ public class AuthController {
      * @return 사용자가 로그인한 상태라면 해당 사용자의 프로필을 기반으로한 약속된 SuccessResponse 반환
      **/
     @GetMapping("/api/auth/status")
-    public ResponseEntity<ApiResponse<Map<String, MemberSummaryDTO>>> checkMemberAuthenticationStatus(@RequestAttribute String username) {
+    public ResponseEntity<ApiResponse<Void>> checkMemberAuthenticationStatus(@RequestAttribute String username) {
         log.info("check session is working");
 
-        MemberSummaryDTO memberSummaryDTO = authService.checkMemberAuthenticationStatus(username);
-
-        return buildSuccessResponseWithPairKeyData("profileDTO", memberSummaryDTO, "유효한 세션입니다.", HttpStatus.OK);
+        return buildSuccessResponseWithoutData("'" + username + "'님의 세션은 유효합니다.", HttpStatus.OK);
     }
 
     /**

--- a/src/main/java/sumcoda/boardbuddy/service/AuthService.java
+++ b/src/main/java/sumcoda/boardbuddy/service/AuthService.java
@@ -7,15 +7,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import sumcoda.boardbuddy.dto.AuthRequest;
 import sumcoda.boardbuddy.dto.AuthResponse;
-import sumcoda.boardbuddy.dto.client.MemberSummaryDTO;
-import sumcoda.boardbuddy.dto.fetch.MemberSummaryProjection;
 import sumcoda.boardbuddy.exception.auth.InvalidPasswordException;
 import sumcoda.boardbuddy.exception.auth.SMSCertificationAttemptExceededException;
 import sumcoda.boardbuddy.exception.auth.SMSCertificationExpiredException;
 import sumcoda.boardbuddy.exception.auth.SMSCertificationNumberMismatchException;
 import sumcoda.boardbuddy.exception.member.MemberRetrievalException;
 import sumcoda.boardbuddy.exception.member.PhoneNumberAlreadyExistsException;
-import sumcoda.boardbuddy.mapper.MemberMapper;
 import sumcoda.boardbuddy.repository.member.MemberRepository;
 import sumcoda.boardbuddy.repository.SmsCertificationRepository;
 import sumcoda.boardbuddy.util.SmsCertificationUtil;
@@ -34,10 +31,6 @@ public class AuthService {
     private final MemberRepository memberRepository;
 
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
-
-    private final CloudFrontSignedUrlService cloudFrontSignedUrlService;
-
-    private final MemberMapper memberMapper;
 
 
     /**
@@ -131,19 +124,6 @@ public class AuthService {
         return !isCertificationNumberExpired(phoneNumber) &&
                 smsCertificationRepository.getSMSCertification(phoneNumber)
                         .equals(validateSMSCertificationDTO.getCertificationNumber());
-    }
-
-    /**
-     * 사용자의 로그인 상태를 확인
-     *
-     * @param username 로그인 사용자 아이디
-     * @return 사용자가 로그인한 상태라면 해당 사용자의 프로필 반환 아니라면 null 반환
-     **/
-    public MemberSummaryDTO checkMemberAuthenticationStatus(String username) {
-        MemberSummaryProjection projection = memberRepository.findMemberSummaryByUsername(username).orElseThrow(() ->
-                new MemberRetrievalException("해당 유저를 찾을 수 없습니다. 관리자에게 문의하세요."));
-
-        return memberMapper.toMemberSummaryDTO(projection);
     }
 
     /**


### PR DESCRIPTION
## #️⃣연관된 이슈

> 이슈번호: #343

## 📝작업 내용

> 로그인 확인 API 요청시 클라이언트로 반환하는 데이터를 변경하기 위한 관련 로직 수정 작업

## 작업 상세 내용

- AuthController
  - checkMemberAuthenticationStatus() 반환 타입 및 데이터, 로직 수정

- MemberService
  - 불필요한 프로퍼티 및 checkMemberAuthenticationStatus() 메서드 삭제