### PR TITLE
[Feature] 과도한 요청 방지를 위한 전역 레이트 리밋 적용 및 429/Retry-After 반환 작업

### DIFF
--- a/nginx.template.conf
+++ b/nginx.template.conf
@@ -1,63 +1,73 @@
-# HTTP를 HTTPS로 리디렉션하는 서버 블록
-server {
-    listen 80;
-    server_name boardbuddi.com www.boardbuddi.com;
+http {
+    # 레이트 리밋 버킷
+    limit_req_zone $binary_remote_addr zone=global_rl:10m rate=10r/s;
 
-    location / {
-        return 301 https://$host$request_uri;
-    }
-}
+    # 전역 레이트 리밋 적용(모든 경로)
+    limit_req zone=global_rl burst=15 nodelay;
+    limit_req_status 429;
+    add_header Retry-After 300 always;
 
-# HTTPS로 서비스하는 서버 블록
-server {
-    listen 443 ssl;
-    server_name boardbuddi.com www.boardbuddi.com;
+    # HTTP를 HTTPS로 리디렉션하는 서버 블록
+    server {
+        listen 80;
+        server_name boardbuddi.com www.boardbuddi.com;
 
-    ssl_certificate ${NGINX_SSL_CERT_PATH};
-    ssl_certificate_key ${NGINX_SSL_KEY_PATH};
-
-    # 중복 설정 제거(/etc/letsencrypt/options-ssl-default.conf 경로의 파일에 이미 작성됨)
-    # ssl_protocols TLSv1.2 TLSv1.3; # 안전하지 않은 구식 프로토콜을 차단하여 서버와 클라이언트 간의 연결이 최신 보안 표준을 따름
-    # ssl_ciphers HIGH:!aNULL:!MD5; # 안전하지 않은 암호화 알고리즘을 제거하여 서버의 보안을 강화하고 강력한 암호화와 해시 알고리즘만 사용하도록 제한
-
-    # let's encrypt 제공 기본 ssl 설정 포함(ssl_protocols, ssl_ciphers가 아래 경로의 파일에 이미 포함됨)
-    include /etc/letsencrypt/options-ssl-nginx.conf;
-
-    # 강력한 Diffie-Hellman 키 교환을 위해 사용됨
-    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
-
-    location /api {
-        proxy_pass http://127.0.0.1:8080; # 백엔드 애플리케이션이 실행 중인 포트
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        location / {
+            return 301 https://$host$request_uri;
+        }
     }
 
-    location /ws {
-        proxy_pass http://127.0.0.1:8080;
-        proxy_http_version 1.1;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_read_timeout 86400s;  # WebSocket 연결 유지 시간
-        proxy_send_timeout 86400s;  # WebSocket 연결 유지 시간
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "Upgrade";
-        proxy_set_header Origin "";
-    }
+    # HTTPS로 서비스하는 서버 블록
+    server {
+        listen 443 ssl;
+        server_name boardbuddi.com www.boardbuddi.com;
 
-    location /api/notifications/subscription {
-        proxy_pass http://127.0.0.1:8080;
-        proxy_http_version 1.1;
-        proxy_read_timeout 86400s;
-        proxy_pass_request_headers on;
-        proxy_set_header Connection "";
-        proxy_set_header Cache-Control "no-cache";
-        proxy_set_header X-Accel-Buffering "no";
-        proxy_set_header Content-Type "text/event-stream";
-        proxy_buffering off;
-        chunked_transfer_encoding on;
+        ssl_certificate ${NGINX_SSL_CERT_PATH};
+        ssl_certificate_key ${NGINX_SSL_KEY_PATH};
+
+        # 중복 설정 제거(/etc/letsencrypt/options-ssl-default.conf 경로의 파일에 이미 작성됨)
+        # ssl_protocols TLSv1.2 TLSv1.3; # 안전하지 않은 구식 프로토콜을 차단하여 서버와 클라이언트 간의 연결이 최신 보안 표준을 따름
+        # ssl_ciphers HIGH:!aNULL:!MD5; # 안전하지 않은 암호화 알고리즘을 제거하여 서버의 보안을 강화하고 강력한 암호화와 해시 알고리즘만 사용하도록 제한
+
+        # let's encrypt 제공 기본 ssl 설정 포함(ssl_protocols, ssl_ciphers가 아래 경로의 파일에 이미 포함됨)
+        include /etc/letsencrypt/options-ssl-nginx.conf;
+
+        # 강력한 Diffie-Hellman 키 교환을 위해 사용됨
+        ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+        location /api {
+            proxy_pass http://127.0.0.1:8080; # 백엔드 애플리케이션이 실행 중인 포트
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location /api/notifications/subscription {
+            proxy_pass http://127.0.0.1:8080;
+            proxy_http_version 1.1;
+            proxy_read_timeout 86400s;
+            proxy_pass_request_headers on;
+            proxy_set_header Connection "";
+            proxy_set_header Cache-Control "no-cache";
+            proxy_set_header X-Accel-Buffering "no";
+            proxy_set_header Content-Type "text/event-stream";
+            proxy_buffering off;
+            chunked_transfer_encoding on;
+        }
+
+        location /ws {
+            proxy_pass http://127.0.0.1:8080;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_read_timeout 86400s;  # WebSocket 연결 유지 시간
+            proxy_send_timeout 86400s;  # WebSocket 연결 유지 시간
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "Upgrade";
+            proxy_set_header Origin "";
+        }
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> 이슈번호: #345

## 📝작업 내용

>  과도한 요청 방지를 위한 전역 레이트 리밋 적용 및 429/Retry-After 반환을 위한 작업

- http 블록에 IP 기반 limit_req 적용 및 과도한 요청 초과 시 429 반환
- 과도한 요청시 일정 시간 대기를 위한 Retry-After 헤더 추가