### PR TITLE
[Refactor] 임박순 조회 시 정렬 기준 수정

### DIFF
--- a/src/main/java/sumcoda/boardbuddy/repository/gatherArticle/GatherArticleRepositoryCustomImpl.java
+++ b/src/main/java/sumcoda/boardbuddy/repository/gatherArticle/GatherArticleRepositoryCustomImpl.java
@@ -278,6 +278,7 @@ public class GatherArticleRepositoryCustomImpl implements GatherArticleRepositor
         List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
 
         if (GatherArticleStatus.SOON.getValue().equals(sort)) {
+            orderSpecifiers.add(gatherArticle.gatherArticleStatus.desc());
             orderSpecifiers.add(gatherArticle.startDateTime.asc());
         }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> This closes #347 

## 📝작업 내용

> GatherArticleRepositoryCustomImpl.java: 임박순 조회 시 모집완료 상태인 모집글의 우선순위를 후순위로 수정 (gatherArticleStatus 기준 내림차순 정렬)